### PR TITLE
Read Run_Setting.txt, smarter..

### DIFF
--- a/SLBcommissioning/conf_struct.h
+++ b/SLBcommissioning/conf_struct.h
@@ -103,183 +103,260 @@ struct detector_t {
   bool isCore;
 } detector;
 
+bool search_string(const std::string &line, const std::string &str, std::string &par){
+
+  std::size_t found  = line.find(str);
+
+  if(found!=std::string::npos) {
+
+    std::size_t found1 = line.find_first_of(":",found);
+    std::size_t found2 = line.find_first_not_of(' ',found1+1);
+    std::size_t found3 = line.find_first_of(' ',found2+1);
+
+    std::string result = line.substr(found2,found3-found2);
+
+    par = result;
+
+    return true;
+
+  }else{
+    return false;
+  }
+
+}
+
+bool search_string(const std::string &line, const std::string &str, int &par){
+
+  std::size_t found  = line.find(str);
+
+  if(found!=std::string::npos) {
+
+    std::size_t found1 = line.find_first_of(":",found);
+    std::size_t found2 = line.find_first_not_of(' ',found1+1);
+    std::size_t found3 = line.find_first_of(' ',found2+1);
+
+    std::string result = line.substr(found2,found3-found2);
+
+    par = std::stoi(result);
+
+    return true;
+
+  }else{
+    return false;
+  }
+
+}
+
+bool search_string(const std::string &line, const std::string &str, bool &par){
+
+  std::size_t found  = line.find(str);
+
+  if(found!=std::string::npos) {
+
+    std::size_t found1 = line.find_first_of(":",found);
+    std::size_t found2 = line.find_first_not_of(' ',found1+1);
+    std::size_t found3 = line.find_first_of(' ',found2+1);
+
+    std::string result = line.substr(found2,found3-found2);
+
+    if(result=="SL_COREMODULE_INTERFACE"){
+      par = true;
+    }else{
+      par=false;
+    }
+
+    return true;
+
+  }else{
+    return false;
+  }
+
+}
+
+bool search_unixT_string(const std::string &line, const std::string &str, std::string &par){
+
+  std::size_t found  = line.find(str);
+
+  if(found!=std::string::npos) {
+
+    std::size_t found1 = line.find_first_of("123456789",found);
+    std::size_t found2 = line.find_first_of(' ',found1);
+
+    std::string result = line.substr(found1,found2-found1);
+
+    par = result;
+
+    return true;
+
+  }else{
+    return false;
+  }
+
+}
+
 void read_configuration_file(TString filename="Run_Settings.txt", bool debug=true) {
 
-  //===== Daughter: 0 SlabIdx: 0 SlabAdd: 1 SL_Board_SerNum: -1 FPGA_Version: V2.3.7  Nb_Of_Connected_ASUs: 1 =====
-
-    
   std::ifstream reading_file(filename);
   if(!reading_file){
     std::cout<<" dameyo - damedame"<<std::endl;
   }
 
-
-  //CRP 11/12/20 initialise bool to check whether we have a core card or a direct interface
-  detector.isCore=false;
-  TString tmpst;
   std::string line;
-  //first line
-  //CRP 7/12/20 For test purposes and later usage we store the beginning of the line (see usual c++ references for details)
-  streampos begin,end;
-  begin = reading_file.tellg();
-  std::cout << "Begin 1: " << begin << std::endl;
-  // == SETTINGS FILE SAVED WITH ILC SL-SOFTWARE VERSION: V2.16  == DATE OF RUN: UnixTime = 1582821640.563 date = 2020.2.27 time = 17h.40m.40s  ===
-  reading_file >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> detector.sl_soft_v >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> detector.date_run_unix >> tmpst>> tmpst >> detector.date_run_date >> tmpst >> tmpst >> detector.date_run_time >> tmpst ;
-
-  //CRP 7/12/20 Playing with positions in the file
-  //CRP The action should bring us back to the beginning of the line (if successful we can analyse the string in parallel to the existing code) 
-  //reading_file.clear();  
-  //reading_file.seekg(begin);  
-  //std::cout << "tellg() returned "
-  //          << std::setw(5) << reading_file.tellg()
-  //          << " after " << line << "\n";
-  // extracing the one character from current location
-  //char c = reading_file.get();
-  // printing the character
-  //cout << "The character 1: " << c << endl;
-  reading_file.clear();  
-  reading_file.seekg(begin);  
-  getline (reading_file,line);
-  std::cout << "Before printing string" << std::endl;
-  std::cout << line << std::endl;
-  //getline (reading_file,line);
-  //std::cout << "CRP Second line: " << line << std::endl; 
-  //std::cout << "begin 1: " <<  begin << std::endl;
-  std::size_t found = line.find("ILC SL-SOFTWARE VERSION:");    
-  //std::cout << "found: " << found << std::endl;
-  std::size_t found1 = line.find_first_of(":",found);
-  //std::cout << "found1: " << found1 << std::endl;
-  std::size_t found2 = line.find_first_not_of(' ',found1+1);
-  //std::cout << "found2: " << found2 << std::endl;
-  //std::cout << "found2: " << found2 << std::endl;
-  //std::cout << "The first non white space is " << line[found2] << std::endl;
-  std::size_t found3 = line.find_first_of(' ',found2+1);
-  std::string version = line.substr(found2,found3-found2);
-  std::cout << "version: " << version << std::endl;
-  found = line.find("UnixTime");
-  found1 = line.find_first_of("123456789",found);
-  found2 = line.find_first_of(' ',found1);
-  std::string unixtime = line.substr(found1,found2-found1);;
-  std::cout << "unixtime: " << unixtime << std::endl;
-
-  
- 
-  std::cout << "After printing string" << std::endl;
-  //CRP
-  if(debug) cout<<detector.sl_soft_v<<" "<<detector.date_run_unix<<" "<< detector.date_run_date <<" "<< detector.date_run_time<<endl;
-  //second line
-  //----------------------
-  //CRP 7/12/20 For test purposes and later usage we store the beginning of the line (see usual c++ references for details)
-  begin = reading_file.tellg();
-  //std::cout << "begin 2: " <<  begin << std::endl;
-  //reading_file.seekg(begin);  
-  // extracing a set of characters from current location
-  //char A[6];
-  //reading_file.read(A, 5);
-  //A[5] = 0;
-  // printing the character stream 
-  //cout << "The character 2+: " << A << endl;
-  
-  // If the Stage is connected:
-  //  == DESY_MOVING_TABLE: CONNECTED LAST_SET_X_POSITION: -800 LAST_SET_Y_POSITION 800 LAST_READ_X_POSITION: 792 LAST_READ_Y_POSITION: -766 ==
-  // reading_file >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst>> tmpst >> tmpst >> tmpst >> tmpst;
-
-  // If the Stage is not connected:
-  // == DESY_MOVING_TABLE: NOT_CONNECTED ==
-  reading_file >> tmpst >> tmpst >> tmpst >> tmpst;
-
-  //== SYSTEM_TYPE: SL_COREMODULE_INTERFACE USB_SerNum: 2.41A FPGA_Version: V2.1.11  NB_Of_Core_Daughters: 1 EXT_CLOCK: 0 ( 1 = YES, 0= NO) ==
-  reading_file >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst>> tmpst >> tmpst >> tmpst >>tmpst;                                                                                
-  reading_file >> tmpst >> tmpst >> tmpst >> tmpst >> detector.usb_sernum >> tmpst >> detector.fpga_ver >> tmpst >> detector.n_core_daughters >> tmpst >> detector.external_clock >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst;
-  if(debug) cout<<" COREMODULE: USB_SerNum " <<detector.usb_sernum<<", FPGA Ver "<<detector.fpga_ver<<", NB_Of_Core_Daughters "<< detector.n_core_daughters<<", EXT_CLOCK "<<detector.external_clock<< "( 1 = YES, 0= NO)"<<endl;
-
-  //CRP Analysing the second line
-  //return to beginning of line
-  //bool iscore(false);
-
-  reading_file.clear();
-  reading_file.seekg(begin);
-
-  getline (reading_file,line);
-  getline (reading_file,line);
-
-  std::cout << "CRP Third line: " << line << std::endl; 
-
-  //reading_file.clear();
-  //reading_file.seekg(begin);
-  
-  //CRP 14/12/20 Check whether we have a CORE Module or a direct interface 
-  found = line.find("SL_COREMODULE_INTERFACE");
-  //of we find a direct interface we retrieve here the number of connected ASUs
+  detector.isCore=false;
   int nconnasu(0);
-  if (found!=std::string::npos) detector.isCore=true; 
-  //CRP 14/12/20 If we don't find a CORE Module we suppose it's the direct interface (if there is a third
-  //interface this part of the code will have to be adjusted
-  else {
-    found = line.find("Nb_Of_Connected_ASUs:");
-    if (found!=std::string::npos) { 
-      found1 = line.find_first_of("123456789",found);
-      found2 = line.find_first_of(' ',found1);
-      //std::string nconnasu_str = line.substr(found1,found2-found1);;
-      nconnasu = std::stoi(line.substr(found1,found2-found1));
-      std::cout << "CRP Number of connected ASUs: " << nconnasu << std::endl;
-    } else std::cout << "Attention: DIRECT INTERFACE BUT NUMBER OF CONNECTED ASUS NOT GIVEN" << std::endl; 
+  int core_ctr=0;
+
+  int daughter_ctr=0;
+  int slab_ctr=0;
+  int asus_ctr=0;
+  int chip_ctr=0;
+  int ch_ctr=0;
+
+
+  // TEST USE
+  int tmp_count=0;
+
+
+  while ( getline(reading_file, line) ) {
+
+    if (line.c_str()[0] != 't') {
+
+      search_string(line,"ILC SL-SOFTWARE VERSION:", detector.sl_soft_v);
+      search_unixT_string(line,"UnixTime =",detector.date_run_unix);
+      search_unixT_string(line,"date =",detector.date_run_date);
+      search_unixT_string(line,"time =",detector.date_run_time);
+
+      search_string(line,"SYSTEM_TYPE:", detector.isCore);
+
+      search_string(line,"USB_SerNum:", detector.usb_sernum);
+      search_string(line,"FPGA_Version:", detector.fpga_ver);
+      search_string(line,"NB_Of_Core_Daughters:", detector.n_core_daughters);
+      search_string(line,"EXT_CLOCK:", detector.external_clock);
+
+      search_string(line,"TriggerType:", detector.trigger_type);
+      search_string(line,"ACQWindowSource:", detector.acq_window_source);
+      search_string(line,"ACQWindow:", detector.acq_window);
+      search_string(line,"DelayBetweenCycle:", detector.acq_delay);
+      search_string(line,"DelayForStartAcq:", detector.start_acq_delay);
+      search_string(line,"ExtSigLevel:", detector.ext_sig_level);
+      bool isLast = search_string(line,"ExtSigEdge:", detector.ext_sig_edge);
+
+      if(isLast) break;
+
+    } // initial check
+
+  } // loop line
+
+
+  if(debug){
+
+    cout << "SL-SOFTWARE VERSION: " << detector.sl_soft_v << "\n";
+    cout << "UnixTime = " << detector.date_run_unix <<", date = "<< detector.date_run_date <<", time = "<< detector.date_run_time <<"\n";
+
+    cout << "SYSTEM_TYPE: " << detector.isCore << "\n";
+    cout << "USB_SerNum: " << detector.usb_sernum << "\n";
+    cout << "FPGA_Version: " << detector.fpga_ver << "\n";
+    cout << "NB_Of_Core_Daughters: " << detector.n_core_daughters << "\n";
+    cout << "EXT_CLOCK: " << detector.external_clock << "\n";
+
+    cout << "TriggerType: " << detector.trigger_type << "\n";
+    cout << "ACQWindowSource: " << detector.acq_window_source << "\n";
+    cout << "ACQWindow: " << detector.acq_window << "\n";
+    cout << "DelayBetweenCycle: " << detector.acq_delay << "\n";
+    cout << "DelayForStartAcq: " << detector.start_acq_delay << "\n";
+    cout << "ExtSigLevel: " << detector.ext_sig_level << "\n";
+    cout << "ExtSigEdge: " << detector.ext_sig_edge << "\n";
+
   }
 
-  std::cout << "CRP iscore ?: " << detector.isCore << std::endl; 
   
-  //third line
-  //----------------------
-  //=== TriggerType: 0  ('0' = FORCE_TRIGGER, '1' = SELF_TRIGGER) ACQWindowSource: 0 ('0' = AUTO, '1'= SOFT_CMD, '2' = EXT_SIG) ACQWindow: 10 (ms) DelayBetweenCycle: 100 (ms) DelayForStartAcq: 0 (5Mhz_Clock period) ExtSigLevel: 0 ('0' = TTL, '1' = NIM, '-1' = NA) ExtSigEdge: 0 ('0' = RISING_EDGE, '1' = FALLING_EDGE, '-1' = NA) ==
-  reading_file >> tmpst >> tmpst >> detector.trigger_type >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> detector.acq_window_source >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> detector.acq_window >> tmpst >> tmpst >> detector.acq_delay >> tmpst >> tmpst >> detector.start_acq_delay >> tmpst  >> tmpst >> tmpst >>detector.ext_sig_level >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> detector.ext_sig_edge >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst ;
-  if(debug) cout<<" Trigger Type: "<<detector.trigger_type << " AcqWindowSource ('0' = AUTO, '1'= SOFT_CMD, '2' = EXT_SIG): " <<detector.acq_window_source << " AcqWindow: "<<detector.acq_window << "ms DelayBetweenCycle: "<<detector.acq_delay<< " (ms) DelayForStartAcq:"<<detector.start_acq_delay<<" (5Mhz_Clock period) ExtSigLevel ('0' = TTL, '1' = NIM, '-1' = NA): " << detector.ext_sig_level << " ExtSigEdge ('0' = RISING_EDGE, '1' = FALLING_EDGE, '-1' = NA): " << detector.ext_sig_edge <<endl;
-
-  //----------------------
-  //CRP 14/12/20 This line is not present in case of a direct interface (at least not at the moment)
   if(detector.isCore) {
-    //=== CORE_DAUGHTER: 0 FPGA_Version: V1.3.1 Nb_Of_Connected_Slabs: 6 ===
-    if(debug) cout<<" N CORE_DAUGHTER: " <<detector.n_core_daughters<<endl;
-    for(int i=0; i<detector.n_core_daughters; i++) {
-      int icore=-1;
-      reading_file >> tmpst >> tmpst  >> icore  >> tmpst >> detector.core_daughter_fpga_ver[i] >> tmpst  >> detector.core_daughter_n_slabs[i] >> tmpst;
-      if(debug) cout<<" CORE_DAUGHTER: " << icore <<" FPGA_Version: " << detector.core_daughter_fpga_ver[i] << " Nb_Of_Connected_Slabs: "<<detector.core_daughter_n_slabs[i]<< endl;
-    }
-  }
-  //----------------------
-  //CRP 14/12/20 Now we make a terrible hack
-  //IF we have the direct interface we set the number of core daughters to 1 and and the number of slabs to 1
-  if(!detector.isCore) {
-    detector.n_core_daughters=1;
-    detector.core_daughter_n_slabs[0]=1;
-    detector.slab[0][0].nb_asus=nconnasu;
-  }
-  //CRP
-  //===== Daughter: 0 SlabIdx: 0 SlabAdd: 1 SL_Board_SerNum: -1 FPGA_Version: V2.3.7  Nb_Of_Connected_ASUs: 1 =====
-  for(int i=0; i<detector.n_core_daughters; i++) {
-    for(int j=0; j<detector.core_daughter_n_slabs[i]; j++) {
-      //CRP in case of direct interface we have to prevent the program from reading the next line 
-      if(detector.isCore) {
-	reading_file >> tmpst >> tmpst >> tmpst >>  tmpst >> detector.slab[i][j].idx >> tmpst >> detector.slab[i][j].add >> tmpst >> detector.slab[i][j].ser_num >> tmpst >> detector.slab[i][j].slb_fpga >> tmpst >> detector.slab[i][j].nb_asus>>tmpst ;
-	if(debug) cout<< " Daughter: " << i << " SlabIdx: "<< detector.slab[i][j].idx<< " SlabAdd: "<<detector.slab[i][j].add << " SL_Board_SerNum: " << detector.slab[i][j].ser_num << " FPGA_Version: "<<detector.slab[i][j].slb_fpga << " Nb_ASUS: "<<detector.slab[i][j].nb_asus<<endl;
-      } 
-      //CRP
-      for(int k=0; k<detector.slab[i][j].nb_asus; k++) {
-	reading_file >> tmpst >> tmpst >> detector.slab[i][j].asu[k].idx;
-	if(debug) cout<< " ASU: "<< detector.slab[i][j].asu[k].idx<<" "<<endl;
 
-	for(int ichip=0; ichip<detector.slab[i][j].asu[k].n_chips; ichip++) {
-	  reading_file >> tmpst >> tmpst >> detector.slab[i][j].asu[k].skiroc[ichip].idx >> tmpst >> detector.slab[i][j].asu[k].skiroc[ichip].id >> tmpst >> detector.slab[i][j].asu[k].skiroc[ichip].feedback_cap >>  tmpst >> detector.slab[i][j].asu[k].skiroc[ichip].threshold_dac >> tmpst >> detector.slab[i][j].asu[k].skiroc[ichip].hold_delay >> tmpst >> detector.slab[i][j].asu[k].skiroc[ichip].fs_peak_time >> tmpst >>detector.slab[i][j].asu[k].skiroc[ichip].gain_selection_threshold;
-	  if(debug) cout<< " ChipIdx: "<< detector.slab[i][j].asu[k].skiroc[ichip].idx << " ChipId: "<< detector.slab[i][j].asu[k].skiroc[ichip].id<< " FeedbackCap: "<< detector.slab[i][j].asu[k].skiroc[ichip].feedback_cap << "  ThresholdDAC: "<< detector.slab[i][j].asu[k].skiroc[ichip].threshold_dac<< " HoldDelay: "<< detector.slab[i][j].asu[k].skiroc[ichip].hold_delay<< " FSPeakTime: " << detector.slab[i][j].asu[k].skiroc[ichip].fs_peak_time <<" GainSelectionThreshold: "<< detector.slab[i][j].asu[k].skiroc[ichip].gain_selection_threshold<<endl;
-                    
-	  for(int ichn=0; ichn<detector.slab[i][j].asu[k].skiroc[ichip].n_channels; ichn++) {
-	    TString tmpst1, tmpst2, tmpst3, tmpst4, tmpst5, tmpst6;
-	    reading_file >> tmpst1 >>tmpst2 >> tmpst3 >> tmpst4 >> detector.slab[i][j].asu[k].skiroc[ichip].mask[ichn] >> tmpst5 >> detector.slab[i][j].asu[k].skiroc[ichip].chn_threshold_adj[ichn] >> tmpst6 >> detector.slab[i][j].asu[k].skiroc[ichip].preamplifier_mask[ichn];
-	    if(debug) cout<< " Chn: " << ichn << " TrigMask: "<< detector.slab[i][j].asu[k].skiroc[ichip].mask[ichn] << " ChThreshold: "<< detector.slab[i][j].asu[k].skiroc[ichip].chn_threshold_adj[ichn]<< " PAMask: "<<detector.slab[i][j].asu[k].skiroc[ichip].preamplifier_mask[ichn]<<endl;
-	  }//End of loop over channels
-	}//End of loop over chips of an ASU
-      }//End of loop over ASUs
-    }//End of loop over slabs connected to a core daughter
-  }//End of loop over core daughters  
+    for (int i = 0; i < detector.n_core_daughters; ++i)
+    {
+      int icore=-1;
+      getline(reading_file, line);
+      search_string(line,"CORE_DAUGHTER:",icore);
+      search_string(line,"FPGA_Version:",detector.core_daughter_fpga_ver[i]);
+      search_string(line,"Nb_Of_Connected_Slabs:",detector.core_daughter_n_slabs[i]);
+    }
+
+    if(debug){
+
+      for(int i=0; i < detector.n_core_daughters; ++i){
+        cout << "FPGA_Version: " << detector.core_daughter_fpga_ver[i] << endl;
+        cout << "Nb_Of_Connected_Slabs: " << detector.core_daughter_n_slabs[i] << endl;
+      }
+
+    }
+
+  }else{
+    
+    getline(reading_file, line);
+    search_string(line,"Nb_Of_Connected_ASUs:",detector.slab[0][0].nb_asus);
+    
+    detector.n_core_daughters         = 1;
+    detector.core_daughter_n_slabs[0] = 1;
+
+  }
+
+
+  for (int i = 0; i < detector.n_core_daughters; i++) {
+    
+    for (int j = 0; j < detector.core_daughter_n_slabs[i]; j++) {
+
+      if (detector.isCore) {
+        
+        getline(reading_file, line);
+        search_string(line,"SlabIdx:",detector.slab[i][j].idx);
+        search_string(line,"SlabAdd:",detector.slab[i][j].add);
+        search_string(line,"SL_Board_SerNum:",detector.slab[i][j].ser_num);
+        search_string(line,"FPGA_Version:",detector.slab[i][j].slb_fpga);
+        search_string(line,"Nb_Of_Connected_ASUs:",detector.slab[i][j].nb_asus);
+
+        if (debug) cout << " Daughter: " << i << " SlabIdx: " << detector.slab[i][j].idx << " SlabAdd: " << detector.slab[i][j].add << " SL_Board_SerNum: " << detector.slab[i][j].ser_num << " FPGA_Version: " << detector.slab[i][j].slb_fpga << " Nb_Of_Connected_ASUs: " << detector.slab[i][j].nb_asus << endl;
+      }
+
+      //CRP
+      for (int k = 0; k < detector.slab[i][j].nb_asus; k++) {
+
+        getline(reading_file,line);
+        search_string(line,"ASU:",detector.slab[i][j].asu[k].idx);
+
+        if (debug) cout << "# ASU: " << detector.slab[i][j].asu[k].idx << " " << endl;
+
+        for (int ichip = 0; ichip < detector.slab[i][j].asu[k].n_chips; ichip++) {
+
+          getline(reading_file,line);
+          search_string(line,"ChipIndex:",detector.slab[i][j].asu[k].skiroc[ichip].idx);
+          search_string(line,"ChipId:",detector.slab[i][j].asu[k].skiroc[ichip].id);
+          search_string(line,"FeedbackCap:",detector.slab[i][j].asu[k].skiroc[ichip].feedback_cap);
+          search_string(line,"ThresholdDAC:",detector.slab[i][j].asu[k].skiroc[ichip].threshold_dac);
+          search_string(line,"HoldDelay:",detector.slab[i][j].asu[k].skiroc[ichip].hold_delay);
+          search_string(line,"FSPeakTime:",detector.slab[i][j].asu[k].skiroc[ichip].fs_peak_time);
+          search_string(line,"GainSelectionThreshold:",detector.slab[i][j].asu[k].skiroc[ichip].gain_selection_threshold);
+          
+          if (debug) cout << "## ChipIndex: " << detector.slab[i][j].asu[k].skiroc[ichip].idx << " ChipId: " << detector.slab[i][j].asu[k].skiroc[ichip].id << "  FeedbackCap: " << detector.slab[i][j].asu[k].skiroc[ichip].feedback_cap << " ThresholdDAC: " << detector.slab[i][j].asu[k].skiroc[ichip].threshold_dac << " HoldDelay: " << detector.slab[i][j].asu[k].skiroc[ichip].hold_delay << " FSPeakTime: " << detector.slab[i][j].asu[k].skiroc[ichip].fs_peak_time << " GainSelectionThreshold: " << detector.slab[i][j].asu[k].skiroc[ichip].gain_selection_threshold << endl;
+
+          for (int ichn = 0; ichn < detector.slab[i][j].asu[k].skiroc[ichip].n_channels; ichn++) {
+
+            getline(reading_file,line);
+            search_string(line,"TrigMask:",detector.slab[i][j].asu[k].skiroc[ichip].mask[ichn]);
+            search_string(line,"ChThreshold:",detector.slab[i][j].asu[k].skiroc[ichip].chn_threshold_adj[ichn]);
+            search_string(line,"PAMask:",detector.slab[i][j].asu[k].skiroc[ichip].preamplifier_mask[ichn]);
+
+            if (debug) cout << "### Ch: " << ichn << " TrigMask: " << detector.slab[i][j].asu[k].skiroc[ichip].mask[ichn] << " ChThreshold: " << detector.slab[i][j].asu[k].skiroc[ichip].chn_threshold_adj[ichn] << " PAMask: " << detector.slab[i][j].asu[k].skiroc[ichip].preamplifier_mask[ichn] << endl;
+
+          } //End of loop over channels
+        
+        } //End of loop over chips of an ASU
+      
+      } //End of loop over ASUs
+    
+    } //End of loop over slabs connected to a core daughter
+
+  } //End of loop over core daughters
+
 }
 
 void mask_full_chip(int idaughter, int islab, int iasu, int ichip) {

--- a/SLBcommissioning/conf_struct.h
+++ b/SLBcommissioning/conf_struct.h
@@ -125,9 +125,7 @@ void read_configuration_file(TString filename="Run_Settings.txt", bool debug=tru
   std::cout << "Begin 1: " << begin << std::endl;
   // == SETTINGS FILE SAVED WITH ILC SL-SOFTWARE VERSION: V2.16  == DATE OF RUN: UnixTime = 1582821640.563 date = 2020.2.27 time = 17h.40m.40s  ===
   reading_file >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> detector.sl_soft_v >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> detector.date_run_unix >> tmpst>> tmpst >> detector.date_run_date >> tmpst >> tmpst >> detector.date_run_time >> tmpst ;
-  //  == DESY_MOVING_TABLE: CONNECTED LAST_SET_X_POSITION: -800 LAST_SET_Y_POSITION 800 LAST_READ_X_POSITION: 792 LAST_READ_Y_POSITION: -766 ==
-  //reading_file >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst>> tmpst >> tmpst >> tmpst >>tmpst;
-  //cout<<" HOLAAAAAAAAAA "<<tmpst;
+
   //CRP 7/12/20 Playing with positions in the file
   //CRP The action should bring us back to the beginning of the line (if successful we can analyse the string in parallel to the existing code) 
   //reading_file.clear();  
@@ -181,10 +179,20 @@ void read_configuration_file(TString filename="Run_Settings.txt", bool debug=tru
   //A[5] = 0;
   // printing the character stream 
   //cout << "The character 2+: " << A << endl;
+  
+  // If the Stage is connected:
+  //  == DESY_MOVING_TABLE: CONNECTED LAST_SET_X_POSITION: -800 LAST_SET_Y_POSITION 800 LAST_READ_X_POSITION: 792 LAST_READ_Y_POSITION: -766 ==
+  // reading_file >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst>> tmpst >> tmpst >> tmpst >> tmpst;
+
+  // If the Stage is not connected:
+  // == DESY_MOVING_TABLE: NOT_CONNECTED ==
+  reading_file >> tmpst >> tmpst >> tmpst >> tmpst;
+
   //== SYSTEM_TYPE: SL_COREMODULE_INTERFACE USB_SerNum: 2.41A FPGA_Version: V2.1.11  NB_Of_Core_Daughters: 1 EXT_CLOCK: 0 ( 1 = YES, 0= NO) ==
   reading_file >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst>> tmpst >> tmpst >> tmpst >>tmpst;                                                                                
   reading_file >> tmpst >> tmpst >> tmpst >> tmpst >> detector.usb_sernum >> tmpst >> detector.fpga_ver >> tmpst >> detector.n_core_daughters >> tmpst >> detector.external_clock >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst >> tmpst;
   if(debug) cout<<" COREMODULE: USB_SerNum " <<detector.usb_sernum<<", FPGA Ver "<<detector.fpga_ver<<", NB_Of_Core_Daughters "<< detector.n_core_daughters<<", EXT_CLOCK "<<detector.external_clock<< "( 1 = YES, 0= NO)"<<endl;
+
   //CRP Analysing the second line
   //return to beginning of line
   //bool iscore(false);


### PR DESCRIPTION
The conf_struct.h is finally improved using search_string function I created.

Basically this version searches string that contains colon ":"
The function searches for the term before the colon and retrieves the string after colon.
No need for `...>>tmpst >> tmpst >> tmpst >>...` no more.

Example) Take a look at one line that looks like following
`== SYSTEM_TYPE: SL_COREMODULE_INTERFACE USB_SerNum: 2.58A FPGA_Version: V2.1.13  NB_Of_Core_Daughters: 1 EXT_CLOCK: 0 ( 1 = YES, 0= NO) ==`
Then the function
`search_string(line,"USB_SerNum:", detector.usb_sernum);`
looks for the string "USB_SerNum:" and stores to `detector.usb_sernum`.
The output should look like
`detector.usb_sernum = 2.58A`

I confirmed that this change produces identical result as previous version, but please review and confirm this.