### PR TITLE
Eventbuilding: Kickoff meeting additions

### DIFF
--- a/eventbuilding/build_events.py
+++ b/eventbuilding/build_events.py
@@ -24,7 +24,7 @@ except ImportError:
     def get_tree_spills(tree, max_entries):
         print("# Going to analyze %i entries..." %max_entries)
         print("# For better progress information: `pip install tqdm`.")
-        print(datetime.now())
+        print("# Start time:", datetime.now())
         progress_bar = ""
         for i, spill in enumerate(tree):
             if i > max_entries:
@@ -261,17 +261,17 @@ class BuildEvents:
         slabs = self._get_slabs(self.in_tree)
         cob_slabs = set(map(int, filter(None, cob_positions_string.split(" "))))
         if ecal_numbers is None:
-            ecal_numbers = EcalNumbers(slabs=slabs, cob_slabs=cob_slabs)
+           ecal_numbers = EcalNumbers(slabs=slabs, cob_slabs=cob_slabs)
         else:
             assert ecal_numbers.slabs == slabs
             assert ecal_numbers.cob_slabs == cob_slabs
 
+        speed_warning_if_python2()
         self.ecal_config = EcalConfig(
             commissioning_folder=commissioning_folder,
             numbers=ecal_numbers,
             **config_file_kws
         )
-
 
     def _get_tree(self, file_name):
         self.in_file = rt.TFile(file_name,"read")

--- a/eventbuilding/build_events.py
+++ b/eventbuilding/build_events.py
@@ -18,9 +18,12 @@ try:
                 break
             yield i, spill
 except ImportError:
+    from datetime import datetime
+
     def get_tree_spills(tree, max_entries):
         print("# Going to analyze %i entries..." %max_entries)
         print("# For better progress information: `pip install tqdm`.")
+        print(datetime.now())
         progress_bar = ""
         for i, spill in enumerate(tree):
             if i > max_entries:
@@ -380,7 +383,7 @@ class BuildEvents:
             # count hits per slab/chan/chip
             b["nhit_slab"][0] = len(set([hit.slab for hit in hits]))
             b["nhit_chip"][0] = len(set([(hit.slab, hit.chip) for hit in hits]))
-            b["nhit_chan"][0] = len(set([(hit.slab, hit.chip, hit.chan) for hit in hits]))
+            b["nhit_chan"][0] = len(set([(hit.slab, hit.chip, hit.chan) for hit in hits if hit.isHit]))
             b["sum_hg"][0] = sum([hit.hg for hit in hits])
             b["sum_energy"][0] = sum([hit.energy for hit in hits])
 

--- a/eventbuilding/build_events.py
+++ b/eventbuilding/build_events.py
@@ -3,9 +3,10 @@ from __future__ import print_function
 
 import argparse
 import collections
+import sys
+
 import numpy as np
 import ROOT as rt
-from array import array
 from help_tools import *
 
 
@@ -37,6 +38,7 @@ except ImportError:
                     ),
                     end="\r",
                 )
+                sys.stdout.flush()
             yield i, spill
 
 
@@ -74,7 +76,7 @@ class BCIDHandler:
             if sum(is_main_bcid_candidate) == 1:
                 main_bcid = bcid_group[np.argmax(is_main_bcid_candidate)]
             else:
-                bcid_group = np.array(bcid_group)
+                bcid_group = np.array(bcid_group, dtype=float)
                 weighted_mean = bcid_group * group_counts / len(bcid_group)
                 weighted_mean -= 0.01  # Choose the smaller BCID when in between.
                 main_bcid = bcid_group[np.argmin(np.abs(bcid_group - weighted_mean))]
@@ -203,46 +205,40 @@ class BuildEvents:
     _in_tree_name = "siwecaldecoded"
     _out_tree_name = "ecal"
 
-    _branch_tags = {
-        "event info": [
+    _branch_tags = [
+        # "event info":
             "event/I",
             "spill/I",
             "bcid/I",
             "prev_bcid/I",
             "next_bcid/I",
-        ],
-        "hit summary": [
+        # "hit summary":
             "nhit_slab/I",
             "nhit_chip/I",
             "nhit_chan/I",
             "nhit_len/I",
             "sum_hg/F",
             "sum_energy/F",
-        ],
         # 64: the number of channels on a chip.
-        "hit id": [
+        # "hit id":
             "hit_slab[nhit_len]/I",
             "hit_chip[nhit_len]/I",
             "hit_chan[nhit_len]/I",
             "hit_sca[nhit_len]/I",
-        ],
-        "hit coord": [
+        # "hit coord":
             "hit_x[nhit_len]/F",
             "hit_y[nhit_len]/F",
             "hit_z[nhit_len]/F",
-        ],
-        "hit readout": [
+        # "hit readout":
             "hit_hg[nhit_len]/I",
             "hit_lg[nhit_len]/I",
             "hit_energy[nhit_len]/F",
             "hit_n_scas_filled[nhit_len]/I",
-        ],
-        "hit booleans": [
+        # "hit booleans":
             "hit_isHit[nhit_len]/I",
             "hit_isMasked[nhit_len]/I",
             "hit_isCommissioned[nhit_len]/I",
-        ],
-    }
+    ]
 
     def __init__(
         self,
@@ -253,7 +249,7 @@ class BuildEvents:
         commissioning_folder=None,
         cob_positions_string="",
         ecal_numbers=None,  # Not provided in CLI. Mainly useful for debugging/changing.
-        **config_file_kws,
+        **config_file_kws
     ):
         self.file_name = file_name
         self.w_config = w_config
@@ -273,7 +269,7 @@ class BuildEvents:
         self.ecal_config = EcalConfig(
             commissioning_folder=commissioning_folder,
             numbers=ecal_numbers,
-            **config_file_kws,
+            **config_file_kws
         )
 
 
@@ -326,7 +322,7 @@ class BuildEvents:
         self.out_file = rt.TFile(out_file_name,"recreate")
         self.out_tree = rt.TTree(self._out_tree_name, "Build ecal events")
 
-        for branch_tag in [bt for bts in self._branch_tags.values() for bt in bts]:
+        for branch_tag in self._branch_tags:
             self._add_branch(branch_tag)
         self._hit_branches = _get_hit_branches(self.out_arrays)
         return self.out_tree

--- a/eventbuilding/help_tools.py
+++ b/eventbuilding/help_tools.py
@@ -35,7 +35,11 @@ class EcalNumbers:
         }
 
         self.bcid_skip_noisy_acquisition_start = 50
+        self.bcid_bad_value = -999
+        self.bcid_drop = [901]
+        self.bcid_drop_retrigger_delta = 2
         self.bcid_merge_delta = 3
+        self.bcid_overflow = 2**12
         self.bcid_too_many_hits = 8000
 
         self.pedestal_min_average = 200
@@ -59,6 +63,9 @@ class EcalNumbers:
         assert all(len(w_conf) == n.n_slabs for w_conf in n.w_config_options.values())
 
         assert type(n.bcid_skip_noisy_acquisition_start) == int
+        assert type(n.bcid_bad_value) == int
+        assert all(type(i_drop) == int for i_drop in n.bcid_drop)
+        assert n.bcid_drop_retrigger_delta >= 0
         assert n.bcid_merge_delta >= 0
         assert type(n.bcid_too_many_hits) == int
 
@@ -150,7 +157,7 @@ class EcalConfig:
             except EventbuildingException as e:
                 print("To run without the lowgain information, use --no_lg.")
                 raise e
-            
+
 
 
     def _get_x_y(self, mapping_file, mapping_file_cob):
@@ -306,7 +313,7 @@ class EcalConfig:
         if np.any(sca_has_bad_pedestal):
             sca_is_used_for_average = pedestal_map > self._N.pedestal_min_average
             channel_can_provide_average = np.expand_dims(
-                sca_is_used_for_average.sum(axis=-1) >= self._N.pedestal_min_scas, 
+                sca_is_used_for_average.sum(axis=-1) >= self._N.pedestal_min_scas,
                 sca_is_used_for_average.ndim - 1,
             )
             pedestal_has_no_fix = np.logical_and(
@@ -356,10 +363,10 @@ class EcalConfig:
 def speed_warning_if_python2():
     if sys.version_info.major == 2:
         print(
-            "Warning: Slow. The eventbuilding is run with python2. " 
+            "Warning: Slow. The eventbuilding is run with python2. "
             "While the code aims to stay python2/3 compatible, "
             "it was found to run significantly faster with python3 "
-            "(x5, see https://github.com/SiWECAL-TestBeam/SiWECAL-TB-analysis/pull/20#issuecomment-982763034)" 
+            "(x5, see https://github.com/SiWECAL-TestBeam/SiWECAL-TB-analysis/pull/20#issuecomment-982763034)"
         )
 
 

--- a/eventbuilding/help_tools.py
+++ b/eventbuilding/help_tools.py
@@ -125,11 +125,12 @@ class EcalHit:
             self.hg -= pedestals_per_sca[self.sca]
         else:
             is_good_pedestal = pedestals_per_sca > self._ecal_config._N.pedestal_min_average
-            if sum(is_good_pedestal) > 0:
+            n_good_pedestals = is_good_pedestal.sum()
+            if n_good_pedestals > 0:
                 pedestal_average = np.mean(pedestals_per_sca[is_good_pedestal])
             else:
                 pedestal_average = 0
-            if sum(is_good_pedestal) < self._ecal_config._N.pedestal_min_scas:
+            if n_good_pedestals < self._ecal_config._N.pedestal_min_scas:
                 self.isCommissioned = 0
             self.hg -= pedestal_average
 

--- a/eventbuilding/help_tools.py
+++ b/eventbuilding/help_tools.py
@@ -240,6 +240,9 @@ class EcalConfig:
             for i_sca in range(ped_map.shape[-1]):
                 n_entries_per_sca = 3  # ped, eped, widthped
                 ped_val = float(v[3 + i_sca * n_entries_per_sca])
+                err_ped_val = float(v[4 + i_sca * n_entries_per_sca])
+                if err_ped_val < 0:
+                    ped_val = 0
                 idx_slab = self._N.slabs.index(int(v[i_slab]))
                 ped_map[idx_slab][int(v[i_chip])][int(v[i_channel])][i_sca] = ped_val
         if self._verbose:
@@ -263,10 +266,13 @@ class EcalConfig:
         i_chip = fields.index("chip")
         i_channel = fields.index("channel")
         i_mpv = fields.index("mpv")
+        i_error_mpv = fields.index("empv")
 
         for line in lines[2:]:
             v = line.split()
             mip_val = float(v[i_mpv])
+            if float(v[i_error_mpv]) < 0:
+                mip_val = 0
             idx_slab = self._N.slabs.index(int(v[i_slab]))
             mip_map[idx_slab][int(v[i_chip])][int(v[i_channel])] = mip_val
         if self._verbose:

--- a/eventbuilding/help_tools.py
+++ b/eventbuilding/help_tools.py
@@ -78,46 +78,6 @@ dummy_config = dict(
 )
 
 
-class EcalHit:
-    def __init__(self, slab, chip, chan, sca, hg, lg, gain_hit_high, ecal_config):
-        self.slab = slab
-        self.chip = chip
-        self.chan = chan
-        self.sca = sca
-        self.hg = hg
-        self.lg = lg
-        self._ecal_config = ecal_config
-        self._idx_slab = self._ecal_config._N.slabs.index(self.slab)
-
-        self.isMasked = self._ecal_config.masked_map[self._idx_slab][self.chip][self.chan]
-        self.isCommissioned = self._ecal_config.is_commissioned_map[self._idx_slab][self.chip][self.chan][self.sca]
-        self._gain_hit_high = gain_hit_high
-
-        self._set_positions()
-        self._pedestal_subtraction()
-        self._mip_calibration()
-
-
-    @property
-    def isHit(self):
-        return int(self._gain_hit_high > 0)
-
-    def _set_positions(self):
-        self.x = self._ecal_config.x[self._idx_slab][self.chip][self.chan]
-        self.y = self._ecal_config.y[self._idx_slab][self.chip][self.chan]
-        self.z = self._ecal_config.z[self._idx_slab][self.chip][self.chan]
-
-
-    def _pedestal_subtraction(self):
-        pedestals_per_sca = self._ecal_config.pedestal_map[self._idx_slab][self.chip][self.chan]
-        self.hg -= pedestals_per_sca[self.sca]
-
-
-    def _mip_calibration(self):
-        mip_value = self._ecal_config.mip_map[self._idx_slab][self.chip][self.chan]
-        self.energy = self.hg / mip_value
-
-
 class EcalConfig:
 
     def __init__(
@@ -236,7 +196,7 @@ class EcalConfig:
             v = line.split()
             for i_sca in range(ped_map.shape[-1]):
                 n_entries_per_sca = 3  # ped, eped, widthped
-                ped_val = float(v[2 + i_sca * n_entries_per_sca])
+                ped_val = float(v[3 + i_sca * n_entries_per_sca])
                 idx_slab = self._N.slabs.index(int(v[i_slab]))
                 ped_map[idx_slab][int(v[i_chip])][int(v[i_channel])][i_sca] = ped_val
         if self._verbose:

--- a/eventbuilding/help_tools.py
+++ b/eventbuilding/help_tools.py
@@ -233,13 +233,14 @@ class EcalConfig:
         i_chip = fields.index("chip")
         i_channel = fields.index("channel")
         i_ped0 = fields.index("ped0")
+        i_ped1 = fields.index("ped1")
+        n_entries_per_sca = i_ped1 - i_ped0
 
 
         for line in lines[2:]:
             v = line.split()
             for i_sca in range(ped_map.shape[-1]):
-                n_entries_per_sca = 3  # ped, eped, widthped
-                ped_val = float(v[3 + i_sca * n_entries_per_sca])
+                ped_val = float(v[i_ped0 + i_sca * n_entries_per_sca])
                 err_ped_val = float(v[4 + i_sca * n_entries_per_sca])
                 if err_ped_val < 0:
                     ped_val = 0

--- a/eventbuilding/help_tools.py
+++ b/eventbuilding/help_tools.py
@@ -101,6 +101,7 @@ class EcalConfig:
         masked_file=dummy_config["masked_file"],
         commissioning_folder=None,
         numbers=None,
+        zero_suppress=True,
         no_lg=False,
         error_on_missing_config=True,
         verbose=False,
@@ -131,6 +132,7 @@ class EcalConfig:
             self.pedestal_map, self.mip_map, self.masked_map
         )
 
+        self.zero_suppress = zero_suppress
         self.no_lg = no_lg
         if self.no_lg:
             print("As requested with --no_lg, low gain will not be calibrated.")

--- a/eventbuilding/help_tools.py
+++ b/eventbuilding/help_tools.py
@@ -99,7 +99,8 @@ class EcalConfig:
         else:
             # Resolves to the root folder of this repo
             # Equivalent to ../ if called from within the eventbuilding folder.
-            self._commissioning_folder = os.path.dirname(os.path.dirname((__file__)))
+            event_building_folder = os.path.dirname(os.path.abspath(__file__))
+            self._commissioning_folder = os.path.dirname(event_building_folder)
         if numbers:
             EcalNumbers.validate_ecal_numbers(numbers)  # Catch problems early on.
             self._N = numbers

--- a/eventbuilding/help_tools.py
+++ b/eventbuilding/help_tools.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from __future__ import print_function
 import os
+import sys
+
 import numpy as np
 
 
@@ -316,6 +318,16 @@ class EcalConfig:
             print("is_commissioned_map", is_commissioned_map)
             print("Rate of commissioned scas: {:.2f}%".format(is_commissioned_map.mean() * 100))
         return is_commissioned_map
+
+
+def speed_warning_if_python2():
+    if sys.version_info.major == 2:
+        print(
+            "Warning: Slow. The eventbuilding is run with python2. " 
+            "While the code aims to stay python2/3 compatible, "
+            "it was found to run significantly faster with python3 "
+            "(x5, see https://github.com/SiWECAL-TestBeam/SiWECAL-TB-analysis/pull/20#issuecomment-982763034)" 
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR replaces #20, additional discussion (e.g. on py2/py3 speed) can be found there.
It implements the features shown during the [SiW-ECAL Kick-off meeting](https://agenda.linearcollider.org/event/9505/) as well as additional features that were requested then, including:

- [x] 🐍 Make the code python2 compatible again.
- [x] *Steering:* Make `gain_hit_bit` a steering flag (default: only keep `hit_isHit`).
- [x] *Steering:* Cut at 4 slabs.
- [x] Drop the BCID-peak.
- [x] Do not use `bcid_corrected`. Instead, do the full bcid correction procedure in eventbuilding.
- [x] New event-level variable: `bcid_first_sca_full`.
- [x] 🐍 Print a *python2-is-slow* message.
- [x] Add `hit_energy_lg`.

An example buildfile from this version can be found at `/eos/project-s/siw-ecal/TB2021-11/beamData/buildfiles/3GeV_22degrees_run_050126_build3.root`.
The wrapper script with the used CLI options can be found [here](https://gist.github.com/kunathj/76f21ea4ea92bf3b2b0f9f7916ec38dc/a8bdf51dec5b76c56f37671bf5f61fdd5635c217).