### PR TITLE
Debugging of the Converter. New badbcid features. New tree varaible names. Improved noise analysis.

### DIFF
--- a/SLBperformance/DecodedSLBAnalysis.cc
+++ b/SLBperformance/DecodedSLBAnalysis.cc
@@ -204,8 +204,8 @@ int DecodedSLBAnalysis::NSlabsAnalysis(TString outputname="", int maxnhit=1, int
        for(int isca=0; isca<15; isca++) {
          TH1F *ped_low_sca2 = new TH1F(TString::Format("ped_low_layer%i_chip%i_chn%i_sca%i",ilayer,ichip,ichn,isca),TString::Format("ped_low_layer%i_chip%i_chn%i_sca%i",ilayer,ichip,ichn,isca),400,100.5,500.5);
          TH1F *ped_high_sca2 = new TH1F(TString::Format("ped_high_layer%i_chip%i_chn%i_sca%i",ilayer,ichip,ichn,isca),TString::Format("ped_high_layer%i_chip%i_chn%i_sca%i",ilayer,ichip,ichn,isca),400,100.5,500.5);
-         TH1F *mip_low_sca2 = new TH1F(TString::Format("mip_low_layer%i_chip%i_chn%i_sca%i",ilayer,ichip,ichn,isca),TString::Format("mip_low_layer%i_chip%i_chn%i_sca%i",ilayer,ichip,ichn,isca),500,100.5,600.5);
-         TH1F *mip_high_sca2 = new TH1F(TString::Format("mip_high_layer%i_chip%i_chn%i_sca%i",ilayer,ichip,ichn,isca),TString::Format("mip_high_layer%i_chip%i_chn%i_sca%i",ilayer,ichip,ichn,isca),500,100.5,600.5);
+         TH1F *mip_low_sca2 = new TH1F(TString::Format("mip_low_layer%i_chip%i_chn%i_sca%i",ilayer,ichip,ichn,isca),TString::Format("mip_low_layer%i_chip%i_chn%i_sca%i",ilayer,ichip,ichn,isca),900,100.5,1000.5);
+         TH1F *mip_high_sca2 = new TH1F(TString::Format("mip_high_layer%i_chip%i_chn%i_sca%i",ilayer,ichip,ichn,isca),TString::Format("mip_high_layer%i_chip%i_chn%i_sca%i",ilayer,ichip,ichn,isca),900,100.5,1000.5);
          ped_lowtemp_sca2.push_back(ped_low_sca2);
          ped_hightemp_sca2.push_back(ped_high_sca2);
          mip_lowtemp_sca2.push_back(mip_low_sca2);
@@ -254,8 +254,7 @@ int DecodedSLBAnalysis::NSlabsAnalysis(TString outputname="", int maxnhit=1, int
 	  if( nhits[ilayer][ichip][isca]>maxnhit ) continue;
 
 	  int bcid_seen = SimpleCoincidenceTagger(ilayer,maxnhit,bcid[ilayer][ichip][isca]);
-	  if(bcid[ilayer][ichip][isca]>10 && badbcid[ilayer][ichip][isca]==0 && bcid_seen>5) cout<<badbcid[ilayer][ichip][isca]<<" "<<ilayer<<" "<<ichip<<" "<<isca<<" "<<bcid[ilayer][ichip][isca]<<" "<<maxnhit<<" "<<bcid_seen<<endl;
-	  
+	 	  
           if(bcid_seen<(nslabshit-1)) continue;
 
             /*int triggers=0;

--- a/SLBperformance/DecodedSLBAnalysis.cc
+++ b/SLBperformance/DecodedSLBAnalysis.cc
@@ -99,10 +99,10 @@ void DecodedSLBAnalysis::HitMonitoring(TString outputname="", int maxnhit=5, int
 
 	  // int ntaggedasbad = 0;
 	  // for(int ichn=0; ichn<64; ichn++) {
-	  //   if(charge_lowGain[ilayer][ichip][isca][ichn]<180 && charge_lowGain[ilayer][ichip][isca][ichn]>-1) {
+	  //   if(adc_low[ilayer][ichip][isca][ichn]<180 && adc_low[ilayer][ichip][isca][ichn]>-1) {
 	  //     ntaggedasbad++;
 	  //   }
-	  //   if(charge_hiGain[ilayer][ichip][isca][ichn]<200 && charge_hiGain[ilayer][ichip][isca][ichn]>-1) {
+	  //   if(adc_high[ilayer][ichip][isca][ichn]<200 && adc_high[ilayer][ichip][isca][ichn]>-1) {
 	  //     ntaggedasbad++;
 	  //   }
 	  // }//ichn 
@@ -268,14 +268,14 @@ int DecodedSLBAnalysis::NSlabsAnalysis(TString outputname="", int maxnhit=1, int
 
 	  for(int ichn=0; ichn<64; ichn++) {
 	    if(hitbit_low[ilayer][ichip][isca][ichn]==0) 
-	      ped_low_sca.at(ilayer).at(ichip).at(ichn).at(isca)->Fill(charge_lowGain[ilayer][ichip][isca][ichn]);
+	      ped_low_sca.at(ilayer).at(ichip).at(ichn).at(isca)->Fill(adc_low[ilayer][ichip][isca][ichn]);
 	    if(hitbit_high[ilayer][ichip][isca][ichn]==0) 
-	      ped_high_sca.at(ilayer).at(ichip).at(ichn).at(isca)->Fill(charge_hiGain[ilayer][ichip][isca][ichn]);
+	      ped_high_sca.at(ilayer).at(ichip).at(ichn).at(isca)->Fill(adc_high[ilayer][ichip][isca][ichn]);
 	    
 	    if(hitbit_low[ilayer][ichip][isca][ichn]==1) 
-	      mip_low_sca.at(ilayer).at(ichip).at(ichn).at(isca)->Fill(charge_lowGain[ilayer][ichip][isca][ichn]);
+	      mip_low_sca.at(ilayer).at(ichip).at(ichn).at(isca)->Fill(adc_low[ilayer][ichip][isca][ichn]);
 	    if(hitbit_high[ilayer][ichip][isca][ichn]==1) 
-	      mip_high_sca.at(ilayer).at(ichip).at(ichn).at(isca)->Fill(charge_hiGain[ilayer][ichip][isca][ichn]);
+	      mip_high_sca.at(ilayer).at(ichip).at(ichn).at(isca)->Fill(adc_high[ilayer][ichip][isca][ichn]);
 	  }
 	}//isca
 	  
@@ -417,8 +417,8 @@ int DecodedSLBAnalysis::NSlabsAnalysisNoise(TString outputname="", int gain=1, i
 	  if(badbcid[ilayer][ichip][isca]!=0) continue;
 
      	  for(int j=0; j<64; j++) {
-	    if(gain==1 && hitbit_high[ilayer][ichip][isca][j]==0 ) h_ped.at(isca).at(ilayer).at(ichip).at(j)->Fill(charge_hiGain[ilayer][ichip][isca][j]);
-	    if(gain==0 && hitbit_low[ilayer][ichip][isca][j]==0 ) h_ped.at(isca).at(ilayer).at(ichip).at(j)->Fill(charge_lowGain[ilayer][ichip][isca][j]);
+	    if(gain==1 && hitbit_high[ilayer][ichip][isca][j]==0 ) h_ped.at(isca).at(ilayer).at(ichip).at(j)->Fill(adc_high[ilayer][ichip][isca][j]);
+	    if(gain==0 && hitbit_low[ilayer][ichip][isca][j]==0 ) h_ped.at(isca).at(ilayer).at(ichip).at(j)->Fill(adc_low[ilayer][ichip][isca][j]);
 	  }
 	  
 	}
@@ -467,16 +467,16 @@ for (Long64_t jentry=0; jentry<nentries;jentry++) {
        
        for(int ichn=0; ichn<64; ichn++) {                   
          if(ped_value.at(isca).at(ilayer).at(ichip).at(ichn)<1 || hitbit_high[ilayer][ichip][isca][ichn]==1 ) continue;
-         if(charge_hiGain[ilayer][ichip][isca][ichn]<0) continue;
+         if(adc_high[ilayer][ichip][isca][ichn]<0) continue;
 
-         double charge=charge_hiGain[ilayer][ichip][isca][ichn]-ped_value.at(isca).at(ilayer).at(ichip).at(ichn);  
-         if(gain==0) charge=charge_lowGain[ilayer][ichip][isca][ichn]-ped_value.at(isca).at(ilayer).at(ichip).at(ichn);
+         double charge=adc_high[ilayer][ichip][isca][ichn]-ped_value.at(isca).at(ilayer).at(ichip).at(ichn);  
+         if(gain==0) charge=adc_low[ilayer][ichip][isca][ichn]-ped_value.at(isca).at(ilayer).at(ichip).at(ichn);
          for(int kchn=0; kchn<64; kchn++) {
            if(ped_value.at(isca).at(ilayer).at(ichip).at(kchn)<1 || hitbit_high[ilayer][ichip][isca][kchn]==1) continue;
-           if(charge_hiGain[ilayer][ichip][isca][kchn]<0) continue;
+           if(adc_high[ilayer][ichip][isca][kchn]<0) continue;
 
-           double charge_k=charge_hiGain[ilayer][ichip][isca][kchn]-ped_value.at(isca).at(ilayer).at(ichip).at(kchn);   
-           if(gain==0) charge_k=charge_lowGain[ilayer][ichip][isca][kchn]-ped_value.at(isca).at(ilayer).at(ichip).at(kchn);    
+           double charge_k=adc_high[ilayer][ichip][isca][kchn]-ped_value.at(isca).at(ilayer).at(ichip).at(kchn);   
+           if(gain==0) charge_k=adc_low[ilayer][ichip][isca][kchn]-ped_value.at(isca).at(ilayer).at(ichip).at(kchn);    
            cov.at(isca).at(ilayer).at(ichip)->Fill(ichn,kchn,charge*charge_k);       
            nevents.at(isca).at(ilayer).at(ichip)->Fill(ichn,kchn);
 

--- a/SLBperformance/Noise.cc
+++ b/SLBperformance/Noise.cc
@@ -4,13 +4,13 @@
 #include "TFile.h"
 #include "DecodedSLBAnalysis.cc"
 
-int Noise(TString filename_in, TString output="", int gain=1, int sca=15){
+int Noise(TString filename_in, TString output="", int gain=1){
 
   cout<<" Display of file: "<<filename_in<<endl;
   DecodedSLBAnalysis ss(filename_in,"siwecaldecoded");
 
   cout<<"Start NSlabsNAalysis"<<endl;
-  int result=ss.NSlabsAnalysisNoise(output,gain,sca);
+  int result=ss.NSlabsAnalysisNoise(output,gain);
   return result;
 
 }

--- a/SLBperformance/Proto.cc
+++ b/SLBperformance/Proto.cc
@@ -15,7 +15,7 @@ int Proto(TString filename_in, TString output="", int monitoring=0){
   int result1=1;
   int result2=1;
   if(monitoring>0) ss.HitMonitoring(output,1000,4);
-  else result2=ss.NSlabsAnalysis(output,5,7);
+  else result2=ss.NSlabsAnalysis(output,2,9);
   return result1*result2;
 
 }

--- a/SLBperformance/TBchecks/analysis.cc
+++ b/SLBperformance/TBchecks/analysis.cc
@@ -1,7 +1,7 @@
 #include "analysis.h"
 
  
-void analysis(TString run="3GeVMIPscan", TString gain="high", bool pedestal=false, bool mip=true, int pedestal_mode=0) {
+void analysis(TString run="3GeVMIPscan", TString gain="high", bool pedestal=false, bool mip=true, int pedestal_mode=0, TString run_pedestal="") {
 
 
   // pedestal_mode==0 --> no subtraction
@@ -24,7 +24,7 @@ void analysis(TString run="3GeVMIPscan", TString gain="high", bool pedestal=fals
   
   if(pedestal==true)  pedanalysis(run,gain);
   else {
-    if(mip==true) mipanalysis_summary(run,gain,pedestal_mode);
+    if(mip==true) mipanalysis_summary(run,gain,pedestal_mode,run_pedestal);
     //    else s_n_analysis_summary(run,gain);
   }
 

--- a/SLBperformance/TBchecks/analysis.sh
+++ b/SLBperformance/TBchecks/analysis.sh
@@ -1,5 +1,12 @@
 #sleep 20s
-root -l -q analysis.cc\(\"test\",\"high\",false,true,1\) 
+for mode in 2 
+do
+    #root -l -q analysis.cc\(\"MIPscan_1.2pF_0.8pF\",\"high\",false,true,$mode,\"run_050571_injection_merged_LowEnergyElectrons\"\)  &
+    #root -l -q analysis.cc\(\"MIPscan_1.2pF_0.8pF\",\"low\",false,true,$mode,\"run_050571_injection_merged_LowEnergyElectrons\"\) &
+    root -l -q analysis.cc\(\"MIPscan_6pF\",\"high\",false,true,$mode,\"run_050575_injection_merged_ILCEnergyElectrons\"\)
+done
+#root -l -q analysis.cc\(\"MIPscan_6pF\",\"low\",false,true,1,\"run_050575_injection_merged_ILCEnergyElectrons\"\)  
+
 #root -l -q analysis.cc\(\"3GeVMIPscan\",\"high\",true\) &
 #root -l	-q analysis.cc\(\"3GeVMIPscan\",\"low\",true\) 
 

--- a/SLBperformance/mipstudy.sh
+++ b/SLBperformance/mipstudy.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+run_counter=0
+initial=${PWD}
+cd /mnt/HardDrive/beamData/mipscan/
+for run in *
+do
+    
+    run_counter=$((run_counter+1))
+    
+    data_folder="/mnt/HardDrive/beamData/mipscan/"${run}"/"
+    cd ${data_folder}
+    FILE_start=${run}"_raw.bin"
+    if test -f "${FILE_start}"; then
+	FILE_new=${FILE_start}"_0000"
+	mv ${FILE_start} ${FILE_new}
+    fi
+    
+    cd $initial
+
+    output="../converter_SLB/convertedfiles/"MIPScan_1.2pF_0.8pF_${run_counter}
+    if [ -d "$output" ]; then
+	cd $output
+	ls -1tr | tail -n -1 | xargs -d '\n' rm -f --
+	cd -
+    else
+	mkdir $output
+    fi
+    
+    cd ../converter_SLB
+    
+    root -l -q ConvertDirectorySL_Raw.cc\(\"${data_folder}\",false,\"${run}\",\"../converter_SLB/convertedfiles/MIPScan_1.2pF_0.8pF_${run_counter}\",2\) &
+    root -l -q ConvertDirectorySL_Raw.cc\(\"${data_folder}\",false,\"${run}\",\"../converter_SLB/convertedfiles/MIPScan_1.2pF_0.8pF_${run_counter}\",1\) &
+    root -l -q ConvertDirectorySL_Raw.cc\(\"${data_folder}\",false,\"${run}\",\"../converter_SLB/convertedfiles/MIPScan_1.2pF_0.8pF_${run_counter}\",0\)
+
+    sleep 2m
+    
+    if [ ${run_counter} -gt 9 ]
+    then
+	hadd convertedfiles/MIPScan_1.2pF_0.8pF_${run_counter}_merged.root convertedfiles/MIPScan_1.2pF_0.8pF_${run_counter}/*root
+    else
+	hadd convertedfiles/MIPScan_1.2pF_0.8pF_0${run_counter}_merged.root convertedfiles/MIPScan_1.2pF_0.8pF_${run_counter}/*root
+    fi
+    cd ../SLBperformance
+
+    if [ ${run_counter} -gt 9 ]
+    then
+	root -l -q Proto.cc\(\"../converter_SLB/convertedfiles/MIPScan_1.2pF_0.8pF_${run_counter}_merged\",\"MIPScan_1.2pF_0.8pF_${run_counter}\",0\) &
+    else
+	root -l -q Proto.cc\(\"../converter_SLB/convertedfiles/MIPScan_1.2pF_0.8pF_0${run_counter}_merged\",\"MIPScan_1.2pF_0.8pF_0${run_counter}\",0\) &
+    fi
+    
+    cd /mnt/HardDrive/beamData/mipscan/
+    
+done
+
+cd $initial
+
+cd ../converter_SLB/convertedfiles/
+hadd MIPScan_1.2pF_0.8pF.root MIPScan_1.2pF_0.8pF*.root
+
+cd $initial
+
+
+cd TBchecks
+source analysis.sh

--- a/SLBperformance/noise_covariance_matrix/analysis/Fit.h
+++ b/SLBperformance/noise_covariance_matrix/analysis/Fit.h
@@ -108,11 +108,11 @@ TH2F* OpenCovMatrix(TString filename="3GeVMIPscan_scagt0",TString gain="highgain
   for (int i=0; i<64; i++) {
     TH1F* htemp=(TH1F*)file->Get(TString::Format("layer_%i/h_ped_layer%i_chip%i_chn%i",layer,layer,chip,i));
     if(htemp==NULL) {
-      cout<<"htemp == NUL"<<endl;
+      cout<<"htemp == NULL"<<endl;
       continue;
     }
-    if(htemp->GetEntries()>100) {
-      htemp->GetXaxis()->SetRangeUser(htemp->GetMean()-20,htemp->GetMean()+20);
+    if(htemp->GetEntries()>50) {
+      htemp->GetXaxis()->SetRangeUser(htemp->GetMean()-15,htemp->GetMean()+15);
       pedestal[i]=htemp->GetMean();
       epedestal[i]=htemp->GetRMS();
     
@@ -159,9 +159,9 @@ int Fit(TString name="3GeVMIPscan", TString gain="highgain", int layer=0, int ch
   Double_t step[nparameters];
   for(int i=0; i<nparameters; i++) {
     if(i<64) {
-      vstart[i]=3.0;
+      vstart[i]=1.0;
       step[i]=0.001;
-      gMinuit->mnparm(i, TString::Format("I_%i",i), vstart[i], step[i], 1.0,100,ierflg);
+      gMinuit->mnparm(i, TString::Format("I_%i",i), vstart[i], step[i], 0.1,100,ierflg);
     } else if(i<128) {
       vstart[i]=0.5;
       step[i]=0.001;
@@ -182,7 +182,7 @@ int Fit(TString name="3GeVMIPscan", TString gain="highgain", int layer=0, int ch
   }
 
   // Now data for minimization step
-  arglist[0] = 20000;//1000;//10000; //2000 for the HG
+  arglist[0] = 500000;//1000;//10000; //2000 for the HG
   arglist[1] = 1;
   gMinuit->SetErrorDef(1);
   gMinuit->mnexcm("MIGRAD", arglist ,1,ierflg);

--- a/SLBperformance/noise_covariance_matrix/analysis/NoiseStudy.C
+++ b/SLBperformance/noise_covariance_matrix/analysis/NoiseStudy.C
@@ -69,7 +69,7 @@ void CreateHistos(TString run="3GeVMIPscan", int igain=0, int isca=0){
 	
 	h2_exy_i->Fill(double(map_pointX[0][chip][j]),double(map_pointY[0][chip][j]),esigma_i[j]);
 	h2_exy_c1->Fill(double(map_pointX[0][chip][j]),double(map_pointY[0][chip][j]),esigma_c1[j]);
-	  h2_exy_c2->Fill(double(map_pointX[0][chip][j]),double(map_pointY[0][chip][j]),esigma_c2[j]);
+	h2_exy_c2->Fill(double(map_pointX[0][chip][j]),double(map_pointY[0][chip][j]),esigma_c2[j]);
       }
       
     }//chip
@@ -104,15 +104,10 @@ void CreateHistos(TString run="3GeVMIPscan", int igain=0, int isca=0){
 
 }
 
-void NoiseStudy(){
+void NoiseStudy(TString run="Pedestal_W_run_050263_merged", int isca=1){
 
-  TString run[1]={"03102022_pedestal_13slabs"};
-  for(int irun=0; irun<1; irun++) {
-    for(int isca=1; isca<16;isca++) {
-      CreateHistos(run[irun],1,isca);
-      CreateHistos(run[irun],0,isca);
-    }
-  }
-
+  CreateHistos(run,1,isca);
+  CreateHistos(run,0,isca);
+  
 }
 

--- a/SLBperformance/noise_covariance_matrix/analysis/SummaryPlots.C
+++ b/SLBperformance/noise_covariance_matrix/analysis/SummaryPlots.C
@@ -1,10 +1,104 @@
 #include "Fit.h"
 
+void Maps(TString name_="3GeVMIPscan",TString st_gain="highgain"){
+
+  int nlayers=15;
+  int nchips=16;
+  int nsca=1;
+  gStyle->SetOptStat(0);
+
+  TFile *_file1 = new TFile(TString::Format("../../../pedestals/PedMaps_method2_%s_%s.root",name_.Data(),st_gain.Data()),"RECREATE");
+  for(int layer=0; layer<nlayers; layer++) {
+
+    for(int isca=0; isca<nsca; isca++) {
+      TString sca=TString::Format("%s_sca%i",st_gain.Data(),isca);
+      TFile *file = TFile::Open(TString::Format("Summary_%s_%s.root",name_.Data(),sca.Data()));
+      
+      TH2F * h2_ped_xy=(TH2F*)file->Get(TString::Format("pedestal_layer%i_xy",layer));
+      TH2F * h2_i_xy=(TH2F*)file->Get(TString::Format("2d noise-incoherent layer%i - xy",layer));
+      TH2F * h2_c1_xy=(TH2F*)file->Get(TString::Format("2d noise-coherent-1 layer%i -xy",layer));
+      TH2F * h2_c2_xy=(TH2F*)file->Get(TString::Format("2d noise-coherent-2 layer%i -xy",layer));
+
+      
+      TH2F * h2_ped=(TH2F*)file->Get(TString::Format("pedestal_layer%i",layer));
+      TH2F * h2_i=(TH2F*)file->Get(TString::Format("2d noise-incoherent layer%i",layer));
+      TH2F * h2_c1=(TH2F*)file->Get(TString::Format("2d noise-coherent-1 layer%i",layer));
+      TH2F * h2_c2=(TH2F*)file->Get(TString::Format("2d noise-coherent-2 layer%i",layer));
+
+   
+      _file1->cd();
+
+      TCanvas* canvas0= new TCanvas(TString::Format("Noise, x-y maps, layer%i",layer),TString::Format("Noise, x-y maps, layer%i",layer),1200,1200);   
+      canvas0->Divide(2,2);
+      canvas0->cd(1);
+      h2_ped_xy->SetTitle("Pedestal, "+name_);
+      h2_ped_xy->GetXaxis()->SetTitle("x");
+      h2_ped_xy->GetYaxis()->SetTitle("y");
+      h2_ped_xy->GetZaxis()->SetRangeUser(180,280);
+      h2_ped_xy->Draw("colz");
+      canvas0->cd(2);
+      h2_i_xy->SetTitle("Incoherent noise, "+name_);
+      h2_i_xy->GetXaxis()->SetTitle("x");
+      h2_i_xy->GetYaxis()->SetTitle("y");
+      h2_i_xy->GetZaxis()->SetRangeUser(0,5);
+      h2_i_xy->Draw("colz");
+      canvas0->cd(3);
+      h2_c1_xy->SetTitle("C1 noise, "+name_);
+      h2_c1_xy->GetXaxis()->SetTitle("x");
+      h2_c1_xy->GetYaxis()->SetTitle("y");
+      h2_c1_xy->GetZaxis()->SetRangeUser(0,5);
+      h2_c1_xy->Draw("colz");
+    
+      canvas0->cd(4);
+      h2_c2_xy->SetTitle("C2 noise, "+name_);
+      h2_c2_xy->GetXaxis()->SetTitle("x");
+      h2_c2_xy->GetYaxis()->SetTitle("y");
+      h2_c2_xy->GetZaxis()->SetRangeUser(0,5);
+      h2_c2_xy->Draw("colz");
+      canvas0->Write();
+      delete canvas0;
+
+      TCanvas* canvas1= new TCanvas(TString::Format("Noise, chip-chn maps, layer%i",layer),TString::Format("Noise, chip-chn maps, layer%i",layer),1200,1200);   
+      canvas1->Divide(2,2);
+      canvas1->cd(1);
+      h2_ped->SetTitle("Pedestal, "+name_);
+      h2_ped->GetXaxis()->SetTitle("chip");
+      h2_ped->GetYaxis()->SetTitle("chn");
+      h2_ped->GetZaxis()->SetRangeUser(180,280);
+      h2_ped->Draw("colz");
+      canvas1->cd(2);
+      h2_i->SetTitle("Incoherent noise, "+name_);
+      h2_i->GetXaxis()->SetTitle("chip");
+      h2_i->GetYaxis()->SetTitle("chn");
+      h2_i->GetZaxis()->SetRangeUser(0,5);
+      h2_i->Draw("colz");
+      canvas1->cd(3);
+      h2_c1->SetTitle("C1 noise, "+name_);
+      h2_c1->GetXaxis()->SetTitle("chip");
+      h2_c1->GetYaxis()->SetTitle("chn");
+      h2_c1->GetZaxis()->SetRangeUser(0,5);
+      h2_c1->Draw("colz");
+    
+      canvas1->cd(3);
+      h2_c2->SetTitle("C2 noise, "+name_);
+      h2_c2->GetXaxis()->SetTitle("chip");
+      h2_c2->GetYaxis()->SetTitle("chn");
+      h2_c2->GetZaxis()->SetRangeUser(0,5);
+      h2_c2->Draw("colz");
+      canvas1->Write();
+      delete canvas1;
+
+    }
+  }
+  
+}
+
+
 void SummaryPedestal(TString name_="3GeVMIPscan",TString st_gain="highgain"){
 
   int nlayers=15;
   int nchips=16;
-  int nsca=4;
+  int nsca=3;
   TH2F* ped=new TH2F("ped","pedestal pos. ; Layer*20+Chip  ; SCA*100 +chn; ADC",300,-0.5,299.5,1500,-0.5,1499.5);
   TH2F* ped_rms=new TH2F("ped_rms","pedestal RMS. ; Layer*20+Chip  ; SCA*100 +chn; ADC",300,-0.5,299.5,1500,-0.5,1499.5);
   TH2F* ped_i=new TH2F("ped_i","pedestal incoherent noise. ; Layer*20+Chip  ; SCA*100 +chn; ADC",300,-0.5,299.5,1500,-0.5,1499.5);
@@ -58,6 +152,8 @@ void SummaryPedestal(TString name_="3GeVMIPscan",TString st_gain="highgain"){
 	  TH2F * h2_i=(TH2F*)file->Get(TString::Format("2d noise-incoherent layer%i",layer));
 	  TH2F * h2_c1=(TH2F*)file->Get(TString::Format("2d noise-coherent-1 layer%i",layer));
 	  TH2F * h2_c2=(TH2F*)file->Get(TString::Format("2d noise-coherent-2 layer%i",layer));
+
+	  
 	  if(h2_ped->GetBinContent(chip+1,j+1)>10) {
 	    pedv+=h2_ped->GetBinContent(chip+1,j+1);
 	    pedrmsv+=h2_eped->GetBinContent(chip+1,j+1);
@@ -182,7 +278,10 @@ void SummaryPedestal(TString name_="3GeVMIPscan",TString st_gain="highgain"){
 }
 
 void SummaryPlots(TString runname="Pedestal_W_run_050263_merged"){
-  SummaryPedestal(runname,"highgain");
-  SummaryPedestal(runname,"lowgain");
+
+  //  SummaryPedestal(runname,"highgain");
+  // SummaryPedestal(runname,"lowgain");
+  Maps(runname,"highgain");
+  Maps(runname,"lowgain");
 }
 

--- a/SLBperformance/pedestal.sh
+++ b/SLBperformance/pedestal.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-for run in "Pedestal_ch0_injection_run_050571" "Pedestal_ch20_injection_run_050572" "Pedestal_ch40_injection_run_050573" "Pedestal_ch60_injection_run_050574"
+for run in "Pedestal_ch0_injection_run_050575" "Pedestal_ch20_injection_run_050576" "Pedestal_ch40_injection_run_050577" "Pedestal_ch60_injection_run_050578"
 do
     initial=${PWD}
     
@@ -26,33 +26,33 @@ do
     
     cd ../converter_SLB
     
-    root -l -q ConvertDirectorySL_Raw.cc\(\"${data_folder}\",false,\"${run}\",\"../converter_SLB/convertedfiles/${run}\",2\) &
-    root -l -q ConvertDirectorySL_Raw.cc\(\"${data_folder}\",false,\"${run}\",\"../converter_SLB/convertedfiles/${run}\",1\) &
-    root -l -q ConvertDirectorySL_Raw.cc\(\"${data_folder}\",false,\"${run}\",\"../converter_SLB/convertedfiles/${run}\",0\)
+    #root -l -q ConvertDirectorySL_Raw.cc\(\"${data_folder}\",false,\"${run}\",\"../converter_SLB/convertedfiles/${run}\",2\) &
+    #root -l -q ConvertDirectorySL_Raw.cc\(\"${data_folder}\",false,\"${run}\",\"../converter_SLB/convertedfiles/${run}\",1\) &
+    #root -l -q ConvertDirectorySL_Raw.cc\(\"${data_folder}\",false,\"${run}\",\"../converter_SLB/convertedfiles/${run}\",0\)
     
     cd -
     
 done
 
 cd ../converter_SLB/convertedfiles/
-hadd -f Pedestal_run_050571_injection_merged.root Pedestal*/*root
+#hadd -f Pedestal_run_050575_injection_merged.root Pedestal*/*root
 
 cd -
 
 cd noise_covariance_matrix
 
-for run in "Pedestal_run_050571_injection_merged"
+for run in "Pedestal_run_050575_injection_merged"
 do
     cd ../
-    root -l -q Noise.cc\(\"../converter_SLB/convertedfiles/${run}.root\",\"${run}\",0\) &
-    root -l -q Noise.cc\(\"../converter_SLB/convertedfiles/${run}.root\",\"${run}\",1\)
-    sleep 1m
+    #root -l -q Noise.cc\(\"../converter_SLB/convertedfiles/${run}.root\",\"${run}\",0\) &
+    #root -l -q Noise.cc\(\"../converter_SLB/convertedfiles/${run}.root\",\"${run}\",1\)
+    #sleep 1m
     cd -
     cd analysis
-    root -l -q NoiseStudy.C\(\"$run\",4\) &
-    root -l -q NoiseStudy.C\(\"$run\",2\) 
-    root -l -q NoiseStudy.C\(\"$run\",3\) &
-    root -l -q NoiseStudy.C\(\"$run\",1\) 
+    #root -l -q NoiseStudy.C\(\"$run\",4\) &
+    #root -l -q NoiseStudy.C\(\"$run\",2\) 
+    #root -l -q NoiseStudy.C\(\"$run\",3\) &
+    #root -l -q NoiseStudy.C\(\"$run\",1\) 
     root -l -q SummaryPlots.C\(\"$run\"\)
     cd -
 done

--- a/SLBperformance/pedestal.sh
+++ b/SLBperformance/pedestal.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+
+for run in "Pedestal_ch0_injection_run_050571" "Pedestal_ch20_injection_run_050572" "Pedestal_ch40_injection_run_050573" "Pedestal_ch60_injection_run_050574"
+do
+    initial=${PWD}
+    
+    data_folder="/mnt/HardDrive/beamData/Pedestals/"${run}"/"
+    cd ${data_folder}
+    FILE_start=${run}"_raw.bin"
+    if test -f "${FILE_start}"; then
+	FILE_new=${FILE_start}"_0000"
+	mv ${FILE_start} ${FILE_new}
+    fi
+    
+    cd -
+
+    output="../converter_SLB/convertedfiles/"${run}
+    if [ -d "$output" ]; then
+	cd $output
+	ls -1tr | tail -n -1 | xargs -d '\n' rm -f --
+	cd -
+    else
+	mkdir $output
+    fi
+    
+    cd ../converter_SLB
+    
+    root -l -q ConvertDirectorySL_Raw.cc\(\"${data_folder}\",false,\"${run}\",\"../converter_SLB/convertedfiles/${run}\",2\) &
+    root -l -q ConvertDirectorySL_Raw.cc\(\"${data_folder}\",false,\"${run}\",\"../converter_SLB/convertedfiles/${run}\",1\) &
+    root -l -q ConvertDirectorySL_Raw.cc\(\"${data_folder}\",false,\"${run}\",\"../converter_SLB/convertedfiles/${run}\",0\)
+    
+    cd -
+    
+done
+
+cd ../converter_SLB/convertedfiles/
+hadd -f Pedestal_run_050571_injection_merged.root Pedestal*/*root
+
+cd -
+
+cd noise_covariance_matrix
+
+for run in "Pedestal_run_050571_injection_merged"
+do
+    cd ../
+    root -l -q Noise.cc\(\"../converter_SLB/convertedfiles/${run}.root\",\"${run}\",0\) &
+    root -l -q Noise.cc\(\"../converter_SLB/convertedfiles/${run}.root\",\"${run}\",1\)
+    sleep 1m
+    cd -
+    cd analysis
+    root -l -q NoiseStudy.C\(\"$run\",4\) &
+    root -l -q NoiseStudy.C\(\"$run\",2\) 
+    root -l -q NoiseStudy.C\(\"$run\",3\) &
+    root -l -q NoiseStudy.C\(\"$run\",1\) 
+    root -l -q SummaryPlots.C\(\"$run\"\)
+    cd -
+done
+
+cd -

--- a/converter_SLB/ConvertDirectorySL_Raw.cc
+++ b/converter_SLB/ConvertDirectorySL_Raw.cc
@@ -1,0 +1,77 @@
+//# Copyright 2020 Adrián Irles IJCLab (CNRS/IN2P3)
+
+#include "TSystemDirectory.h"
+#include "TCanvas.h"
+#include "TROOT.h"
+#include "TGraph.h"
+#include "TF1.h"
+#include "TLatex.h"
+#include <sstream>
+#include <iostream>
+#include <fstream>
+#include "SLBraw2ROOT.cc"
+
+
+using namespace std;
+
+vector<TString>* list_files(const char *dirname, const char *ext="_raw.bin")
+{
+	TSystemDirectory dir(dirname, dirname);
+	TList* files = dir.GetListOfFiles();
+	vector<TString>* filenames = new vector<TString>();
+	
+	if (files)
+	{
+		TSystemFile *file;
+		TString fname;
+		TIter next(files);
+		while ((file=(TSystemFile*)next()))
+		{
+			fname = file->GetName();
+			if (!file->IsDirectory() && fname.EndsWith(ext))
+			{
+				filenames->push_back(dirname+fname);
+			}
+		}
+	}
+	return filenames;
+}
+
+void ConvertDirectorySL_Raw(string dirname, bool zerosupression=false, TString run="0", TString outputname="default", int jinitial=0)
+{
+
+  std::cout << "dirname " << dirname << std::endl; 
+
+  for(int j=jinitial; j<5000; j+=3) {
+    //for(int j=0; j<1; j++) {
+    
+    TString filen="_raw.bin";
+    if(j==0) filen=TString::Format("%s_raw.bin_000%i",run.Data(),j);
+    if(j>0 && j<10) filen=TString::Format("%s_raw.bin_000%i",run.Data(),j);
+    if(j>9 && j<100) filen=TString::Format("%s_raw.bin_00%i",run.Data(),j);
+    if(j>99 && j<1000) filen=TString::Format("%s_raw.bin_0%i",run.Data(),j);
+    if(j>999 && j<10000) filen=TString::Format("%s_raw.bin_%i",run.Data(),j);
+   
+    TString output="default";
+    if(outputname!="default") output=TString::Format("%s/converted_%s.root",outputname.Data(),filen.Data());
+    
+    vector<TString>* filenames = list_files(dirname.c_str(),filen.Data());
+    if(filenames->size()!=1) {
+      std::cout << "N files != 0 !!!  for "<< filen << std::endl;
+      break;
+    }
+    
+    SLBraw2ROOT *ss;
+
+    ss->_maxReadOutCycleJump=10;
+    bool result=false;
+    while(result==false) {
+      result=ss->ReadFile((*filenames)[0], true, output);
+      ss->_maxReadOutCycleJump*=10;
+    }
+    delete ss;
+    
+  }
+  
+  gSystem->Exit(0);
+}

--- a/converter_SLB/ConvertDirectorySL_Raw.cc
+++ b/converter_SLB/ConvertDirectorySL_Raw.cc
@@ -61,15 +61,15 @@ void ConvertDirectorySL_Raw(string dirname, bool zerosupression=false, TString r
       break;
     }
     
-    SLBraw2ROOT *ss;
+    SLBraw2ROOT ss;
 
-    ss->_maxReadOutCycleJump=10;
+    ss._maxReadOutCycleJump=10;
     bool result=false;
     while(result==false) {
-      result=ss->ReadFile((*filenames)[0], true, output);
-      ss->_maxReadOutCycleJump*=10;
+      result=ss.ReadFile((*filenames)[0], true, output);
+      ss._maxReadOutCycleJump*=10;
     }
-    delete ss;
+    //    delete ss;
     
   }
   

--- a/converter_SLB/RawConvertDataSL.cc
+++ b/converter_SLB/RawConvertDataSL.cc
@@ -4,7 +4,12 @@ using namespace std;
 
 int RawConvertDataSL(TString filename, bool zerosupression=false, TString outputname="default", bool getbadbcid_bool=false){
     SLBraw2ROOT ss;
-    ss.ReadFile(filename, true, outputname, zerosupression, getbadbcid_bool);
+    ss._maxReadOutCycleJump=10;
+    bool result=false;
+    while(result==false) {
+      result=ss.ReadFile(filename, true, outputname, zerosupression, getbadbcid_bool);
+      ss._maxReadOutCycleJump*=10;
+    }
     gSystem->Exit(0);
     return 0;
 }

--- a/converter_SLB/RawConvertDataSL.cc
+++ b/converter_SLB/RawConvertDataSL.cc
@@ -2,7 +2,7 @@
 
 using namespace std;
 
-int RawConvertDataSL(TString filename, bool zerosupression=false, TString outputname="default", bool getbadbcid_bool=false){
+int RawConvertDataSL(TString filename, bool zerosupression=false, TString outputname="default", bool getbadbcid_bool=true){
     SLBraw2ROOT ss;
     ss._maxReadOutCycleJump=10;
     bool result=false;

--- a/converter_SLB/SLBraw2ROOT.cc
+++ b/converter_SLB/SLBraw2ROOT.cc
@@ -112,10 +112,10 @@ protected:
   float AVDD1; // in Volts
   int sca;
   int core, slab;
-  int chargevalue_low[NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
+  int adcvalue_low[NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
   int gainvalue_low[NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
   int hitvalue_low[NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
-  int chargevalue_high[NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
+  int adcvalue_high[NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
   int gainvalue_high[NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
   int hitvalue_high[NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
   int valid_frame;
@@ -146,8 +146,8 @@ protected:
   int _corrected_bcid[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC];
   int _badbcid[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC];
   int _nhits[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC];
-  int _charge_low[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
-  int _charge_high[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
+  int _adc_low[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
+  int _adc_high[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
   int _autogainbit_low[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
   int _autogainbit_high[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
   int _hitbit_low[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
@@ -211,10 +211,10 @@ void SLBraw2ROOT::InitializeRawFrame() {
     nhits[i]=0;
     bcid[i]=0;
     for(int j=0; j<NB_OF_CHANNELS_IN_SKIROC; j++) {
-      chargevalue_low[i][j]=0;
+      adcvalue_low[i][j]=0;
       gainvalue_low[i][j]=0;
       hitvalue_low[i][j]=0;
-      chargevalue_high[i][j]=0;
+      adcvalue_high[i][j]=0;
       gainvalue_high[i][j]=0;
       hitvalue_high[i][j]=0;
     }
@@ -375,11 +375,11 @@ bool SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
 	  
 	  rawData = (unsigned short)ucharValFrameVec.at(index+2*channel) + ((unsigned short)ucharValFrameVec.at(index+1+2*channel) << 8);
 	  rawValue = (int)(rawData & 0xFFF);
-	  gainalue_high[sca][channel] =  (rawData & 0x1000)>>12;
+	  gainvalue_high[sca][channel] =  (rawData & 0x1000)>>12;
 	  hitvalue_high[sca][channel] =  (rawData & 0x2000)>>13;
-	  int chargeValuetemp =  Convert_FromGrayToBinary(rawValue , 12); 
-	  chargevalue_high[sca][channel] = chargeValuetemp;
-	  if(_debug) std::cout<<"chn:"<<channel<<" gainvalue_1:"<<gainvalue_high[sca][channel]<<" hitvalue_1:"<<hitvalue_high[sca][channel]<<" "<<"chargeValue_1:"<<chargevalue_high[sca][channel]<<std::endl;
+	  int adcValuetemp =  Convert_FromGrayToBinary(rawValue , 12); 
+	  adcvalue_high[sca][channel] = adcValuetemp;
+	  if(_debug) std::cout<<"chn:"<<channel<<" gainvalue_1:"<<gainvalue_high[sca][channel]<<" hitvalue_1:"<<hitvalue_high[sca][channel]<<" "<<"adcValue_1:"<<adcvalue_high[sca][channel]<<std::endl;
 	  
 	}
       
@@ -393,9 +393,9 @@ bool SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
 	  rawValue = (int)(rawData & 0xFFF);
 	  gainvalue_low[sca][channel] =  (rawData & 0x1000)>>12;
 	  hitvalue_low[sca][channel] =  (rawData & 0x2000)>>13;  
-	  int chargeValuetemp = Convert_FromGrayToBinary(rawValue , 12);
-	  chargevalue_low[sca][channel] = chargeValuetemp;
-	  if(_debug) std::cout<<"chn:"<<channel<<" gainvalue_0:"<<gainvalue_low[sca][channel]<<" hitvalue_0:"<<hitvalue_low[sca][channel]<<" "<<"chargeValue_0:"<<chargevalue_low[sca][channel]<<std::endl;
+	  int adcValuetemp = Convert_FromGrayToBinary(rawValue , 12);
+	  adcvalue_low[sca][channel] = adcValuetemp;
+	  if(_debug) std::cout<<"chn:"<<channel<<" gainvalue_0:"<<gainvalue_low[sca][channel]<<" hitvalue_0:"<<hitvalue_low[sca][channel]<<" "<<"adcValue_0:"<<adcvalue_low[sca][channel]<<std::endl;
 	  if(hitvalue_low[sca][channel]>0) nhits[sca]++;
 	}
 				
@@ -414,7 +414,7 @@ bool SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
 	//Ch 0 LG 282 0 0 HG 296 0 0
 	std::cout<<"##"<<nbOfSingleSkirocEventsInFrame-sca_ascii-1<<" BCID "<<bcid[sca]<<" SCA "<<sca_ascii<<" #Hits "<<nhits[sca]<<std::endl;
 	for(channel = 0; channel < NB_OF_CHANNELS_IN_SKIROC; channel++)
-	  std::cout<<"Ch "<<channel<<" LG "<< chargevalue_low[sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<hitvalue_low[sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<gainvalue_low[sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" HG "<< chargevalue_high[sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<hitvalue_high[sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<gainvalue_high[sca][channel-1]<<std::endl;
+	  std::cout<<"Ch "<<channel<<" LG "<< adcvalue_low[sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<hitvalue_low[sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<gainvalue_low[sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" HG "<< adcvalue_high[sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<hitvalue_high[sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<gainvalue_high[sca][channel-1]<<std::endl;
       }
       skirocEventNumber++;
       
@@ -731,11 +731,11 @@ bool SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
     name= TString::Format("nhits[%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC);
     tree->Branch("nhits",_nhits,name);
 
-    name= TString::Format("lowGain[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
-    tree->Branch("charge_lowGain",_charge_low,name);
+    name= TString::Format("adc_low[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
+    tree->Branch("adc_low",_adc_low,name);
 
-    name= TString::Format("highGain[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
-    tree->Branch("charge_hiGain",_charge_high,name);
+    name= TString::Format("adc_high[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
+    tree->Branch("adc_high",_adc_high,name);
 
     name= TString::Format("autogainbit_low[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
     tree->Branch("autogainbit_low",_autogainbit_low,name);
@@ -762,8 +762,8 @@ bool SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
 	  _corrected_bcid[isl][k][i]=-999;
 	  _nhits[isl][k][i]=-999;
 	  for (int j=0; j<NB_OF_CHANNELS_IN_SKIROC; j++) {
-	    _charge_low[isl][k][i][j]=-999;
-	    _charge_high[isl][k][i][j]=-999;
+	    _adc_low[isl][k][i][j]=-999;
+	    _adc_high[isl][k][i][j]=-999;
 	    _autogainbit_low[isl][k][i][j]=-999;
 	    _autogainbit_high[isl][k][i][j]=-999;
 	     _hitbit_low[isl][k][i][j]=-999;
@@ -826,10 +826,10 @@ bool SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
       if(zerosupression==false) nchn=NB_OF_CHANNELS_IN_SKIROC;
       else nchn = nhits[isca];
       for(int ichn=0; ichn<nchn; ichn++) {
-	_charge_low[slabAdd][chipId][isca][ichn]=chargevalue_low[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
+	_adc_low[slabAdd][chipId][isca][ichn]=adcvalue_low[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
 	_autogainbit_low[slabAdd][chipId][isca][ichn]=gainvalue_low[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
 	_hitbit_low[slabAdd][chipId][isca][ichn]=hitvalue_low[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
-	_charge_high[slabAdd][chipId][isca][ichn]=chargevalue_high[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
+	_adc_high[slabAdd][chipId][isca][ichn]=adcvalue_high[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
 	_hitbit_high[slabAdd][chipId][isca][ichn]=gainvalue_high[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
 	_autogainbit_high[slabAdd][chipId][isca][ichn]=hitvalue_high[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
 	
@@ -949,7 +949,7 @@ bool SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
 	    //	count_negdata=0;
 	
 	    //	for (int ichan=0; ichan<NB_OF_CHANNELS_IN_SKIROC; ichan++) {
-	    //  if  (charge_high[i][k][ibc][ichan] < NEGDATA_THR) count_negdata++;
+	    //  if  (adc_high[i][k][ibc][ichan] < NEGDATA_THR) count_negdata++;
 	    //}//ichan
 
 	    //if (count_negdata>0) {_badbcid[i][k][ibc]+=32;}

--- a/converter_SLB/SLBraw2ROOT.cc
+++ b/converter_SLB/SLBraw2ROOT.cc
@@ -32,7 +32,8 @@ using std::endl;
 #define NB_OF_CHANNELS_IN_SKIROC 64
 #define NB_OF_SCAS_IN_SKIROC 15
 #define SINGLE_SKIROC_EVENT_SIZE (129*2) 
-#define SLBDEPTH 15 
+#define SLBDEPTH 15
+#define NB_CORE_DAUGHTERS 1 
 #define NEGDATA_THR 11
 #define BCIDTHRES 4
 
@@ -68,22 +69,25 @@ class SLBraw2ROOT {
   
 public:
   SLBraw2ROOT(){
-    _ASCIIOUT = true;
+    _ASCIIOUT = false;
     _debug = false;
+    _debug2 = false;
     _eudaq=false;
+    _maxReadOutCycleJump=10;
   }
   ~SLBraw2ROOT(){
   };
   
   void ReadFile(TString inputFileName, bool overwrite=false, TString outFileName = "default", bool zerosupression=false, bool getbadbcid_bool=true);
 
- protected:
+protected:
 
   // general
   bool _ASCIIOUT;
   bool _debug;
+  bool _debug2;
   bool _eudaq;
-  
+  int _maxReadOutCycleJump;
   // -------- RAW DATA
   int coreDaughterIndex;
   int chipId;
@@ -109,23 +113,27 @@ public:
   float AVDD1; // in Volts
   int sca;
   int core, slab;
-  int chargevalue[2][SINGLE_SKIROC_EVENT_SIZE][NB_OF_CHANNELS_IN_SKIROC];
-  int gainvalue[2][SINGLE_SKIROC_EVENT_SIZE][NB_OF_CHANNELS_IN_SKIROC];
-  int hitvalue[2][SINGLE_SKIROC_EVENT_SIZE][NB_OF_CHANNELS_IN_SKIROC];
+  int chargevalue_low[NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
+  int gainvalue_low[NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
+  int hitvalue_low[NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
+  int chargevalue_high[NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
+  int gainvalue_high[NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
+  int hitvalue_high[NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
   int valid_frame;
-  int bcid[SINGLE_SKIROC_EVENT_SIZE];
+  int bcid[NB_OF_SCAS_IN_SKIROC];
   int skirocEventNumber;
-  int nhits[SINGLE_SKIROC_EVENT_SIZE];
+  int nhits[NB_OF_SCAS_IN_SKIROC];
 
   void InitializeRawFrame();
   void DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec);
-
+  int cycleIDDecoding(std::vector<unsigned char> ucharValFrameVec);
 
   // ROOT CONVERSION
-    int R2Rstate;
+  int R2Rstate;
 
   void Initialisation();
   void treeInit(bool);
+  void RecordCycle(bool);
   //  int  GetTree(TString rootfilename);
   void GetBadBCID();
 
@@ -168,6 +176,18 @@ public:
 // RAW ANALYSIS
 void SLBraw2ROOT::InitializeRawFrame() {
 
+  cycleID  = -1;
+  transmitID = -1;
+  startAcqTimeStamp = -1;
+  rawTSD = -1;
+  rawAVDD0 = -1;
+  rawAVDD1 = -1;
+  temperature = 0.0; // in °C
+  AVDD0 = 0.0; // in Volts
+  AVDD1 = 0.0; // in Volts
+  i=0;
+  n=0;
+  
   coreDaughterIndex=-1;
   chipId=-1;
   asuIndex=-1; 
@@ -175,49 +195,56 @@ void SLBraw2ROOT::InitializeRawFrame() {
   skirocIndex=-1;
   datasize=0;
   nbOfSingleSkirocEventsInFrame=0;
-  frame=0; n=0 ; i=0;
+  frame=0;
   rawData=0;
   index=0;
   channel=0;
   rawValue=-1;
   slabAdd=-1;
   trailerWord=0;
-  rawTSD =-1;
-  rawAVDD0=-1; rawAVDD1=-1;
-  cycleID=-1;
-  transmitID=-1;
-  startAcqTimeStamp=-1;
-  temperature=0; // in °C
-  AVDD0 = 0.0; // in Volts
-  AVDD1 = 0.0; // in Volts
+
   sca=-1;
   core=-1; slab=-1;
-  for(int j=0; j<SINGLE_SKIROC_EVENT_SIZE; j++) {
-    bcid[j]=0;
-    for(int i=0; i<2; i++) {
-      for(int k=0; k<NB_OF_CHANNELS_IN_SKIROC; k++) {
-  	chargevalue[i][j][k]=0;
-  	gainvalue[i][j][k]=0;
-  	hitvalue[i][j][k]=0;
-      }
+
+  for(int i=0; i<NB_OF_SCAS_IN_SKIROC; i++) {
+    nhits[i]=0;
+    bcid[i]=0;
+    for(int j=0; j<NB_OF_CHANNELS_IN_SKIROC; j++) {
+      chargevalue_low[i][j]=0;
+      gainvalue_low[i][j]=0;
+      hitvalue_low[i][j]=0;
+      chargevalue_high[i][j]=0;
+      gainvalue_high[i][j]=0;
+      hitvalue_high[i][j]=0;
     }
   }
+  
   valid_frame=0;
 
 
 }
 
+int SLBraw2ROOT::cycleIDDecoding(std::vector<unsigned char> ucharValFrameVec ) {
+  i=0;
+  n=0;
+  // metadata
+  int result=0;
+  for(n= 0; n < 16; n++)
+    {
+      result += ((unsigned int)(((ucharValFrameVec.at(2*n+1)& 0xC0)>> 6) << (30-2*i)));
+      i++;
+    }
+  if(_debug) std::cout<<"cycleIDDecoding:"<<dec<<result<<std::endl;
+  i=0;
+  n=0;
+
+  return result;
+
+}
+
 void SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
-  chipId = ucharValFrameVec.at(datasize -2-2);
-  if(_debug) std::cout<<"chipId:"<<dec<<chipId<<std::endl;
-  if(_debug) std::cout<<"AsuIndex:"<<dec<<(int)(chipId/NB_OF_SKIROCS_PER_ASU)<<std::endl;
-  asuIndex = (int)(chipId/NB_OF_SKIROCS_PER_ASU);
-  if(_debug) std::cout<<"SkirocIndex:"<<dec<<chipId - asuIndex*NB_OF_SKIROCS_PER_ASU<<std::endl;
-  skirocIndex = chipId -asuIndex*NB_OF_SKIROCS_PER_ASU;
 
-  nbOfSingleSkirocEventsInFrame =  (int)((datasize-2-2)/SINGLE_SKIROC_EVENT_SIZE);
-  if(_debug) std::cout<<"nbOfSingleSkirocEventsInFrame: "<<dec<<nbOfSingleSkirocEventsInFrame<<std::endl;
-
+  sca=0;
   cycleID  = 0;
   transmitID = 0;
   startAcqTimeStamp = 0;
@@ -229,6 +256,29 @@ void SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
   AVDD1 = 0.0; // in Volts
   i=0;
   n=0;
+  index=0;
+
+  coreDaughterIndex=ucharValFrameVec.at(0);//(dataResult >> (8*0)) & 0xff;//(unsigned char)dataResult;
+  if(_debug) cout<<"CoreDaughterIndex "<<coreDaughterIndex<<endl;
+  slabIndex=ucharValFrameVec.at(1);//(dataResult >> (8*1)) & 0xff;//(unsigned char)dataResult;
+  if(_debug) cout<<"SlabIndex "<<slabIndex<<endl;
+  slabAdd=slabIndex;
+
+  //remove the first two words
+  ucharValFrameVec.erase(ucharValFrameVec.begin());
+  ucharValFrameVec.erase(ucharValFrameVec.begin());
+
+  int actualdatasize=ucharValFrameVec.size();
+  chipId = ucharValFrameVec.at(actualdatasize -2-2);
+  if(_debug) std::cout<<"chipId:"<<dec<<chipId<<std::endl;
+  if(_debug) std::cout<<"AsuIndex:"<<dec<<(int)(chipId/NB_OF_SKIROCS_PER_ASU)<<std::endl;
+  asuIndex = (int)(chipId/NB_OF_SKIROCS_PER_ASU);
+  if(_debug) std::cout<<"SkirocIndex:"<<dec<<chipId - asuIndex*NB_OF_SKIROCS_PER_ASU<<std::endl;
+  skirocIndex = chipId -asuIndex*NB_OF_SKIROCS_PER_ASU;
+
+  nbOfSingleSkirocEventsInFrame =  (int)((actualdatasize-2-2)/SINGLE_SKIROC_EVENT_SIZE);
+  if(_debug) std::cout<<"nbOfSingleSkirocEventsInFrame: "<<dec<<nbOfSingleSkirocEventsInFrame<<std::endl;
+
   // metadata
   for(n= 0; n < 16; n++)
     {
@@ -242,8 +292,8 @@ void SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
     {
       startAcqTimeStamp += ((unsigned int)(((ucharValFrameVec.at(2*n+1)& 0xC0)>> 6) << (30-2*n)));
       i++;
-   }
-      if(_debug) std::cout<<"startAcqTimeStamp:"<<dec<<startAcqTimeStamp<<std::endl;
+    }
+  if(_debug) std::cout<<"startAcqTimeStamp:"<<dec<<startAcqTimeStamp<<std::endl;
 
   // TSD Value  12 bits value
   i=0; 	
@@ -254,7 +304,7 @@ void SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
       i++;
     }
 
-      if(_debug) std::cout<<"rawTSD:"<<dec<<rawTSD<<std::endl;
+  if(_debug) std::cout<<"rawTSD:"<<dec<<rawTSD<<std::endl;
 	    
   temperature = -0.00035207* pow((float)rawTSD, 2)+2.102526*rawTSD-2946.38;
   // AVDD0 value
@@ -280,7 +330,7 @@ void SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
       i++;
 	
     }
-        if(_debug) std::cout<<"rawAVDD1:"<<dec<<rawAVDD1<<std::endl;
+  if(_debug) std::cout<<"rawAVDD1:"<<dec<<rawAVDD1<<std::endl;
 
   AVDD1 = 1.212766*(rawAVDD1*3.3)/4095.0; 
 
@@ -291,13 +341,13 @@ void SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
       transmitID += ((unsigned int)(((ucharValFrameVec.at(2*n + 1)& 0xC0)>> 6) << (6-2*i)));   // MSB
       i++;
     }
-      if(_debug) std::cout<<"transmitID:"<<dec<<transmitID<<std::endl;
+  if(_debug) std::cout<<"transmitID:"<<dec<<transmitID<<std::endl;
 
   // actual decoding
   for(n= 0; n < nbOfSingleSkirocEventsInFrame; n++)
     {
 
-      rawValue = (int)ucharValFrameVec.at(datasize -2*(n+1)-2-2) + ((int)(ucharValFrameVec.at(datasize -1 -2*(n+1)-2) & 0x0F)<<8) ;   
+      rawValue = (int)ucharValFrameVec.at(actualdatasize -2*(n+1)-2-2) + ((int)(ucharValFrameVec.at(actualdatasize -1 -2*(n+1)-2) & 0x0F)<<8) ;   
       int sca_ascii = nbOfSingleSkirocEventsInFrame-n-1;
       sca=nbOfSingleSkirocEventsInFrame-(sca_ascii+1);
       if(coreDaughterIndex == -1)
@@ -315,13 +365,15 @@ void SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
 
       for(channel = 0; channel < NB_OF_CHANNELS_IN_SKIROC; channel++)
 	{
+	  if(_debug) std::cout<<"chn:"<<channel<<"index:"<<index<<endl;
+
 	  rawData = (unsigned short)ucharValFrameVec.at(index+2*channel) + ((unsigned short)ucharValFrameVec.at(index+1+2*channel) << 8);
 	  rawValue = (int)(rawData & 0xFFF);
-	  hitvalue[1][sca][channel] =  (rawData & 0x1000)>>12;
-	  gainvalue[1][sca][channel] =  (rawData & 0x2000)>>13;
+	  hitvalue_high[sca][channel] =  (rawData & 0x1000)>>12;
+	  gainvalue_high[sca][channel] =  (rawData & 0x2000)>>13;
 	  int chargeValuetemp =  Convert_FromGrayToBinary(rawValue , 12); 
-	  chargevalue[1][sca][channel] = chargeValuetemp;
-	  if(_debug) std::cout<<"chn:"<<channel<<" gainvalue_1:"<<gainvalue[1][sca][channel]<<" hitvalue_1:"<<hitvalue[1][sca][channel]<<" "<<"chargeValue_1:"<<chargevalue[1][sca][channel]<<std::endl;
+	  chargevalue_high[sca][channel] = chargeValuetemp;
+	  if(_debug) std::cout<<"chn:"<<channel<<" gainvalue_1:"<<gainvalue_high[sca][channel]<<" hitvalue_1:"<<hitvalue_high[sca][channel]<<" "<<"chargeValue_1:"<<chargevalue_high[sca][channel]<<std::endl;
 
 	}
 		
@@ -330,14 +382,15 @@ void SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
       nhits[sca]=0;
       for(channel = 0; channel < NB_OF_CHANNELS_IN_SKIROC; channel++)
 	{
+	  if(_debug) std::cout<<"chn:"<<channel<<endl;
 	  rawData = (unsigned short)ucharValFrameVec.at(index+2*channel) + ((unsigned short)ucharValFrameVec.at(index+1+2*channel) << 8);
 	  rawValue = (int)(rawData & 0xFFF);
-	  hitvalue[0][sca][channel] =  (rawData & 0x1000)>>12;
-	  gainvalue[0][sca][channel] =  (rawData & 0x2000)>>13;  
+	  hitvalue_low[sca][channel] =  (rawData & 0x1000)>>12;
+	  gainvalue_low[sca][channel] =  (rawData & 0x2000)>>13;  
 	  int chargeValuetemp = Convert_FromGrayToBinary(rawValue , 12);
-	  chargevalue[0][sca][channel] = chargeValuetemp;
-	  if(_debug) std::cout<<"chn:"<<channel<<" gainvalue_0:"<<gainvalue[0][sca][channel]<<" hitvalue_0:"<<hitvalue[0][sca][channel]<<" "<<"chargeValue_0:"<<chargevalue[0][sca][channel]<<std::endl;
-	  if(hitvalue[0][sca][channel]>0) nhits[sca]++;
+	  chargevalue_low[sca][channel] = chargeValuetemp;
+	  if(_debug) std::cout<<"chn:"<<channel<<" gainvalue_0:"<<gainvalue_low[sca][channel]<<" hitvalue_0:"<<hitvalue_low[sca][channel]<<" "<<"chargeValue_0:"<<chargevalue_low[sca][channel]<<std::endl;
+	  if(hitvalue_low[sca][channel]>0) nhits[sca]++;
 	}
 				
       index += (NB_OF_CHANNELS_IN_SKIROC*2);
@@ -346,137 +399,128 @@ void SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
 
       if(_ASCIIOUT){
 	//#0 Size 1 ChipID 9 coreIdx 0 slabIdx 0 slabAdd 0 Asu 0 SkirocIndex 9 transmitID 0 cycleID 2 StartTime 56717 rawTSD 3712 rawAVDD0 2017 rawAVDD1 2023 tsdValue 36.02 avDD0 1.971 aVDD1 1.977
-	if( (nbOfSingleSkirocEventsInFrame-sca_ascii-1) == 0) std::cout<<"#"<<skirocEventNumber<<" Size "<<nbOfSingleSkirocEventsInFrame<<" ChipID "<<chipId<<" coreIdx "<<coreDaughterIndex<<" slabIdx "<<slabIndex<<" slabAdd "<<slabAdd<<
-	  " Asu "<<asuIndex<<" SkirocIndex "<<skirocIndex<<" transmitID "<<transmitID<<" cycleID "<<cycleID<<" StartTime "<<startAcqTimeStamp<<
-	  " rawTSD "<<rawTSD<<" rawAVDD0 "<<rawAVDD0<<" rawAVDD1 "<<rawAVDD1<<" tsdValue "<<temperature<<
-	  " avDD0 "<<AVDD0<<" aVDD1 "<<AVDD1<<endl;
+	if( (nbOfSingleSkirocEventsInFrame-sca_ascii-1) == 0)
+	  std::cout<<"#"<<skirocEventNumber<<" Size "<<nbOfSingleSkirocEventsInFrame<<" ChipID "<<chipId<<" coreIdx "<<coreDaughterIndex<<" slabIdx "<<slabIndex<<" slabAdd "<<slabAdd<<
+	    " Asu "<<asuIndex<<" SkirocIndex "<<skirocIndex<<" transmitID "<<transmitID<<" cycleID "<<cycleID<<" StartTime "<<startAcqTimeStamp<<
+	    " rawTSD "<<rawTSD<<" rawAVDD0 "<<rawAVDD0<<" rawAVDD1 "<<rawAVDD1<<" tsdValue "<<temperature<<
+	    " avDD0 "<<AVDD0<<" aVDD1 "<<AVDD1<<endl;
 	//##0 BCID 53 SCA 0 #Hits 1
 	//Ch 0 LG 282 0 0 HG 296 0 0
 	std::cout<<"##"<<nbOfSingleSkirocEventsInFrame-sca_ascii-1<<" BCID "<<bcid[sca]<<" SCA "<<sca_ascii<<" #Hits "<<nhits[sca]<<std::endl;
 	for(channel = 0; channel < NB_OF_CHANNELS_IN_SKIROC; channel++)
-	  std::cout<<"Ch "<<channel<<" LG "<< chargevalue[0][sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<hitvalue[0][sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<gainvalue[0][sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" HG "<< chargevalue[1][sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<hitvalue[1][sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<gainvalue[1][sca][channel-1]<<std::endl;
-	  }
+	  std::cout<<"Ch "<<channel<<" LG "<< chargevalue_low[sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<hitvalue_low[sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<gainvalue_low[sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" HG "<< chargevalue_high[sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<hitvalue_high[sca][NB_OF_CHANNELS_IN_SKIROC-channel-1]<<" "<<gainvalue_high[sca][channel-1]<<std::endl;
+      }
       skirocEventNumber++;
+      
     }
+ if(_debug) cout<<"endDECODING"<<endl;
 
 }
 
-void SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString outFileName = "default", bool zerosupression=false, bool getbadbcid_bool=true) {
+  void SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString outFileName = "default", bool zerosupression=false, bool getbadbcid_bool=true) {
 
  
-  ifstream fin;
-  unsigned int dataResult=0;
-  _event=0;
-  _acqNumber=0;
+    ifstream fin;
+    unsigned int dataResult=0;
+    _event=0;
+    _acqNumber=0;
   
-  if(outFileName == "default"){
-    outFileName = TString::Format("%s.root",inputFileName.Data());
-    cout<<outFileName<<endl;
-  }
-  
-  if(!overwrite){
-    fout = new TFile(outFileName,"create");
-    if(!fout->IsOpen()){
-      return;
+    if(outFileName == "default"){
+      outFileName = TString::Format("%s.root",inputFileName.Data());
+      cout<<outFileName<<endl;
     }
-  }
-  else {
-    fout = new TFile(outFileName,"recreate");
-  }
   
-  fin.open(inputFileName.Data(), ios_base::in|ios_base::binary);
+    if(!overwrite){
+      fout = new TFile(outFileName,"create");
+      if(!fout->IsOpen()){
+	return;
+      }
+    }
+    else {
+      fout = new TFile(outFileName,"recreate");
+    }
+  
+    fin.open(inputFileName.Data(), ios_base::in|ios_base::binary);
 
-  Initialisation();// Initialise branchs
+    Initialisation();// Initialise branchs
 
-  skirocEventNumber=0;
-  bool initfilefound=false;
+    skirocEventNumber=0;
+    bool initfilefound=false;
 
-  cout<<" Read File "<<inputFileName<<endl;
+    cout<<" Read File "<<inputFileName<<endl;
 
-  int cycleswithdata=0;
-  int totalcycles=0;
-  int initialcycle=0;
-  int previouscycle=0;
-  double previousstart=0;
 
-  TH1F * h1 = new TH1F("cyclerates","CycleID - previousCycleID; cycleID-previousCycleID; entries",500,-0.5,499.5);
-  TH1F * h2 = new TH1F("start_acq_rates","StartAcq - previousStartAcq; startAcq-previousStartAcq; entries",1000,-0.5,999.5);
-  TH1F * h3 = new TH1F("size_event","Size event (total); Total Number of words; entries",100,0,500);
-  TH2F * h4 = new TH2F("size_vs_cyclerates","Ocuppancy ; cycleID-previousCycleID; Eventsize previous event",100,-0.5,99.5,100,0,500);
-  TH2F * h5 = new TH2F("size_consecutivecyclces","Eventsize previous event (DeltaCycle=1) ; ASIC ; LAYER",16,-0.5,15.5,15,-0.5,14.5);
-  TH2F * h6 = new TH2F("size_nonconsecutivecyclces","Eventsize previous event (DeltaCycle>1) ; ASIC ; LAYER",16,-0.5,15.5,15,-0.5,14.5);
-  TH1F * h7 = new TH1F("wrongly_reconstructed_cycles","wrongly_reconstructed_cycles",4320000,0.5,4320000.5);
-  int event_size=0;
-  int event_size_prev=0;
-  int max_event_size[15][16]={0};
-  int max_event_size_prev[15][16]={0};
+    //one map of cycles per slboard
+    //why per slboard? because the slboad-add is not in the raw dataframes but in the 
+    std::map<int, std::vector<std::vector<unsigned char> > >map_of_cycles_and_frames;
+  
+  
+    int cycleswithdata=0;
+    int lastcycleid=-1;
+    int firstcycleid=-1;
 
-  int max_event_size_prev_=0;
-  float consecevents=0;
-  float nonconsecevents=0;
-
-  while(fin.is_open()) {
+    while(fin.is_open()) {
  
-      if(_debug) std::cout<<" hex:"<<hex<<dataResult<<"  dec:"<<dec<<dataResult<<std::endl;
-      
+      if(_debug2) std::cout<<" hex:"<<hex<<dataResult<<"  dec:"<<dec<<dataResult<<std::endl;
+
       InitializeRawFrame();
 
       bool firstframe=false;
       bool readframe=false;
-      if(_eudaq) {
-	//EUDAQ RAW FRAME
-	if(firstframe==false && initfilefound==false) {
-	  unsigned char temp_char;
-	  fin.read((char*)&temp_char, sizeof(unsigned char));
-	  if(_debug) std::cout<<" hex:"<<hex<<temp_char<<"  dec:"<<dec<<temp_char<<std::endl;
+      /*  if(_eudaq) {
+      //EUDAQ RAW FRAME
+      if(firstframe==false && initfilefound==false) {
+      unsigned char temp_char;
+      fin.read((char*)&temp_char, sizeof(unsigned char));
+      if(_debug2) std::cout<<" hex:"<<hex<<temp_char<<"  dec:"<<dec<<temp_char<<std::endl;
 
-	  if(temp_char==0xAB) {
-	    fin.read((char*)&temp_char, sizeof(unsigned char));
-	    if(temp_char==0xCD) {
-	      firstframe=true;
-	      initfilefound=true;
-	      if(_debug) cout<<"FIRST FRAME FOUND "<<endl;
-	    }
-	  }
-	}
-	
-	if( (0xFFFF & dataResult) == 0xABCD || firstframe==true) {
-	  if(_debug) std::cout<<" HEADER "<<std::endl;
-	  //  if(firstframe==true) fin.read((char *)&dataResult, sizeof(dataResult));
-		
-	  unsigned char buffer[8];
-	  unsigned char ucharVal0;
-	  fin.read((char *)&ucharVal0, sizeof(ucharVal0));
-	  unsigned char ucharVal1;
-	  fin.read((char *)&ucharVal1, sizeof(ucharVal1));
-	  unsigned char ucharVal2;
-	  fin.read((char *)&ucharVal2, sizeof(ucharVal2));
-
-	  //  datasize=((dataResult & 0xFFFF0000) >>16);
-	  datasize=  ((unsigned short)ucharVal1 << 8) + ucharVal0;
-
-	  if(_debug) cout<<"EventSize "<<datasize<<endl;
-	  if(datasize<0) continue;
-	  if(_debug) std::cout<<" hex:"<<hex<<dataResult<<"  dec:"<<dec<<dataResult<<std::endl;
-	  
-	  nbOfSingleSkirocEventsInFrame=0;
-	  
-	  for(int ibuf=0; ibuf<5; ibuf++) {
-	    unsigned char ucharVal;
-	    fin.read((char *)&ucharVal, sizeof(ucharVal));
-	    if(ibuf==0) coreDaughterIndex=ucharVal;
-	    if(ibuf==3) slabAdd=ucharVal;
-	    if(ibuf==4) slabIndex=ucharVal;
-	    if(slabIndex==255) slabIndex=0;// for the USB conection we don't have address
-	  }
-	  
-	  if(_debug) cout<<"CoreDaughterIndex "<<coreDaughterIndex<<endl;
-	  if(_debug) cout<<"SlabAdd "<<slabAdd<<endl;
-	  if(_debug) cout<<"SlabIndex "<<slabIndex<<endl;
-	  readframe=true;
-	  firstframe=false;
-	}
+      if(temp_char==0xAB) {
+      fin.read((char*)&temp_char, sizeof(unsigned char));
+      if(temp_char==0xCD) {
+      firstframe=true;
+      initfilefound=true;
+      if(_debug2) cout<<"FIRST FRAME FOUND "<<endl;
       }
+      }
+      }
+	
+      if( (0xFFFF & dataResult) == 0xABCD || firstframe==true) {
+      if(_debug2) std::cout<<" HEADER "<<std::endl;
+      //  if(firstframe==true) fin.read((char *)&dataResult, sizeof(dataResult));
+		
+      unsigned char buffer[8];
+      unsigned char ucharVal0;
+      fin.read((char *)&ucharVal0, sizeof(ucharVal0));
+      unsigned char ucharVal1;
+      fin.read((char *)&ucharVal1, sizeof(ucharVal1));
+      unsigned char ucharVal2;
+      fin.read((char *)&ucharVal2, sizeof(ucharVal2));
+
+      //  datasize=((dataResult & 0xFFFF0000) >>16);
+      datasize=  ((unsigned short)ucharVal1 << 8) + ucharVal0;
+
+      if(_debug) cout<<"EventSize "<<datasize<<endl;
+      if(datasize<0) continue;
+      if(_debug2) std::cout<<" hex:"<<hex<<dataResult<<"  dec:"<<dec<<dataResult<<std::endl;
+	  
+      nbOfSingleSkirocEventsInFrame=0;
+	  
+      for(int ibuf=0; ibuf<5; ibuf++) {
+      unsigned char ucharVal;
+      fin.read((char *)&ucharVal, sizeof(ucharVal));
+      if(ibuf==0) coreDaughterIndex=ucharVal;
+      if(ibuf==3) slabAdd=ucharVal;
+      if(ibuf==4) slabIndex=ucharVal;
+      if(slabIndex==255) slabIndex=0;// for the USB conection we don't have address
+      }
+	  
+      if(_debug) cout<<"CoreDaughterIndex "<<coreDaughterIndex<<endl;
+      if(_debug) cout<<"SlabAdd "<<slabAdd<<endl;
+      if(_debug) cout<<"SlabIndex "<<slabIndex<<endl;
+      readframe=true;
+      firstframe=false;
+      }
+      }*/
       if(!_eudaq) {
 	if(firstframe==false && initfilefound==false) {
 	  unsigned char temp_char;
@@ -495,370 +539,381 @@ void SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
 	}
 	
 	if( firstframe==true || dataResult == 0xEEEEEEEE ) {
+	  
+	  
 	  if(_debug) std::cout<<" HEADER "<<std::endl;
 	  fin.read((char*)&skirocEventNumber, sizeof(int));
 	  if(_debug) cout<<"skirocEventNumber "<<skirocEventNumber<<endl;
-	  unsigned char ucharVal;
-	  if(_debug) cout<<"skirocEventNumber "<<skirocEventNumber<<endl;
-	  fin.read((char *)&ucharVal, sizeof(ucharVal));
-	  coreDaughterIndex=ucharVal;//(dataResult >> (8*0)) & 0xff;//(unsigned char)dataResult;
-	  if(_debug) cout<<"CoreDaughterIndex "<<coreDaughterIndex<<endl;
 	  
-	  fin.read((char *)&ucharVal, sizeof(ucharVal));
-	  slabIndex=ucharVal;//(dataResult >> (8*1)) & 0xff;//(unsigned char)dataResult;
-	  if(_debug) cout<<"SlabIndex "<<slabIndex<<endl;
+	  std::vector<unsigned char> ucharValFrameVec;
 	  
-	  slabAdd=slabIndex;
+	  for(int j=0; j<2; j++) {
+	    unsigned char ucharValFrame;
+	    fin.read((char *)&ucharValFrame, sizeof(unsigned char));
+	    ucharValFrameVec.push_back(ucharValFrame);
+	  }
 	  
 	  fin.read((char *)&dataResult, sizeof(int));
 	  datasize=dataResult;
 	  if(_debug) cout<<"EventSize "<<datasize<<endl;
-	  readframe=true;
-	  firstframe=false;
-	}
-      }
-      
-      if(readframe==true && datasize>0) {
-	std::vector<unsigned char> ucharValFrameVec;
-	for(int j=0; j<datasize; j++) {
-	  unsigned char ucharValFrame;
-	  fin.read((char *)&ucharValFrame, sizeof(unsigned char));
-	  ucharValFrameVec.push_back(ucharValFrame);
-	  if(_debug) std::cout<<" LOOP, j="<<j<<" hex:"<<hex<<ucharValFrame<<"  dec:"<<dec<<ucharValFrame<<std::endl;
-	}
-	trailerWord =   ((unsigned short)ucharValFrameVec.at(datasize -1) << 8) + ucharValFrameVec.at(datasize -2);
-	if(_debug) std:cout<<"Trailer Word hex:"<<hex<<trailerWord<<" dec:"<<dec<<trailerWord<<std::endl;
-	if(trailerWord == 0x9697) {
-	  DecodeRawFrame(ucharValFrameVec);
-	  event_size+=ucharValFrameVec.size();
-	  max_event_size[slabAdd][chipId]+=ucharValFrameVec.size();
-	  if(_debug) std::cout<<"ACQNumber:"<<dec<<_acqNumber<<" cycleID:"<<cycleID<<" sca:"<<sca<<std::endl;
-	  if( (cycleID-_acqNumber )< 0) {
-	    std::cout<<" ****************************************************"<<endl;
-	    std::cout<<"ERROR, THIS CYCLE"<<_acqNumber<<" AND THIS CYCLE "<<cycleID<<" ARE TO BE REMOVED FROM THE ANALYSIS"<<endl;
-	    h7->Fill(cycleID);
-	    h7->Fill(_acqNumber);
-	  }
-	  // FILL trees
-	  if(_acqNumber==0) treeInit(zerosupression);
-	  if(_acqNumber==-1 && cycleID>0) initialcycle=cycleID;
-	  if(_acqNumber>0 && _acqNumber!=cycleID) {
-	    if(getbadbcid_bool==true) GetBadBCID();
-	    totalcycles=_acqNumber-initialcycle;
-	    tree->Fill();
-	    treeInit(zerosupression);
-	    cycleswithdata++;
-	    h1->Fill(cycleID-previouscycle);
-	    h2->Fill((startAcqTimeStamp-previousstart)/1000.);
-	    h3->Fill(max_event_size_prev_);
-	    h4->Fill((cycleID-previouscycle),max_event_size_prev_);
-	    max_event_size_prev_=0;
-
-	    for(int i=0; i<15; i++) {
-	      for(int j=0; j<16; j++) {
-		if( (cycleID-previouscycle)==1) {
-		  h5->Fill(j,i,max_event_size_prev[i][j]);
-		  consecevents++;
-		}
-		if( (cycleID-previouscycle)>1) {
-		  h6->Fill(j,i,max_event_size_prev[i][j]);
-		  nonconsecevents++;
-		}
-		if(max_event_size[i][j]>max_event_size_prev_) max_event_size_prev_=max_event_size[i][j];
-		max_event_size_prev[i][j]=max_event_size[i][j];
-		max_event_size[i][j]=0;
-	      }
-	    }
-
-	    previouscycle=cycleID;
-	    previousstart=startAcqTimeStamp;
-	    event_size_prev=event_size;
-	    event_size=0;
-	  }
-	  _acqNumber=cycleID;
-	  _n_slboards=SLBDEPTH;
-	  int previousBCID=-1000;
-	  int loopBCID=0;
 	  
-	  _startACQ[slabAdd]=startAcqTimeStamp;
-	  _rawTSD[slabAdd]=rawTSD;
-	  _TSD[slabAdd]=temperature;
-	  _rawAVDD0[slabAdd]=rawAVDD0;
-	  _rawAVDD1[slabAdd]=rawAVDD1;
-	  _AVDD0[slabAdd]=AVDD0;
-	  _AVDD1[slabAdd]=AVDD1;
 	  
-	  _slot[slabAdd]=-1;//we don't know this information... the DQ only provides addresses.
-	  _slboard_id[slabAdd]=slabAdd;
-
-	  for(int isca=0; isca<nbOfSingleSkirocEventsInFrame; isca++) {
-	    _bcid[slabAdd][chipId][isca]=bcid[isca];
-	    _nhits[slabAdd][chipId][isca]=nhits[isca];
-	    _numCol[slabAdd][chipId]=isca+1;
-	    if(_bcid[slabAdd][chipId][isca] > 0 && _bcid[slabAdd][chipId][isca]-previousBCID < 0) loopBCID++;
-	    if(_bcid[slabAdd][chipId][isca] > 0 ) _corrected_bcid[slabAdd][chipId][isca] = _bcid[slabAdd][chipId][isca]+loopBCID*4096;
-	    previousBCID=bcid[isca];
+	  for(int j=0; j<datasize; j++) {
+	    unsigned char ucharValFrame;
+	    fin.read((char *)&ucharValFrame, sizeof(unsigned char));
+	    ucharValFrameVec.push_back(ucharValFrame);
+	    if(_debug2) std::cout<<" LOOP, j="<<j<<" hex:"<<hex<<ucharValFrame<<"  dec:"<<dec<<ucharValFrame<<std::endl;
+	  }
+	  trailerWord =   ((unsigned short)ucharValFrameVec.at(datasize+2 -1) << 8) + ucharValFrameVec.at(datasize+2 -2);
+	  if(_debug) std:cout<<"Trailer Word hex:"<<hex<<trailerWord<<" dec:"<<dec<<trailerWord<<std::endl;
+	  if(trailerWord == 0x9697) {
 	    
-	    if(chipId>-1 && chipId<16) {
-	      _chipId[slabAdd][chipId]=chipId;
+	    int latestfoundcycle=cycleIDDecoding(ucharValFrameVec);
+	    lastcycleid=latestfoundcycle;
+	    if(firstcycleid==-1) firstcycleid=latestfoundcycle;
+	    std::map<int, std::vector<std::vector<unsigned char>>>::iterator it;
+	    it=map_of_cycles_and_frames.find(latestfoundcycle);
+	    if( it == map_of_cycles_and_frames.end() ) {
+	      //new cycle
+	      std::vector<std::vector<unsigned char> > new_vector_of_frames;
+	      new_vector_of_frames.push_back(ucharValFrameVec);
+	      map_of_cycles_and_frames[latestfoundcycle]=new_vector_of_frames;
 	    } else {
-	      cout<<"Wrong chipId = "<<chipId<<endl;
-	      break;
+	      //existing cycle ID
+	      it->second.push_back(ucharValFrameVec);
 	    }
-	    int nchn=0;
-	    if(zerosupression==false) nchn=NB_OF_CHANNELS_IN_SKIROC;
-	    else nchn = nhits[isca];
-	    for(int ichn=0; ichn<nchn; ichn++) {
-	      _charge_low[slabAdd][chipId][isca][ichn]=chargevalue[0][isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
-	      _gain_hit_low[slabAdd][chipId][isca][ichn]=hitvalue[0][isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
-	      _charge_high[slabAdd][chipId][isca][ichn]=chargevalue[1][isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
-	      _gain_hit_high[slabAdd][chipId][isca][ichn]=hitvalue[1][isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
-	      //	      cout<<ichn<<" ---- "<<chargevalue[1][isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1]<<" "<<hitvalue[1][isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1]<<endl;
-	    }
-	  }//end isca
-	}else{
-	  cout<<"WARNING NO TRAILER FOUND!"<<endl;
-	}
-	
-      }
+	    
+	    if(map_of_cycles_and_frames.size()> _maxReadOutCycleJump) {
 
+
+	      if(_debug) std::cout<<"MapSize:"<<map_of_cycles_and_frames.size()<<endl;
+
+	      cycleswithdata++;
+	      //sorting the map
+	      std::vector<pair<int, std::vector<std::vector<unsigned char> > > > map_dumped_into_a_vector;
+	      copy(map_of_cycles_and_frames.begin(),
+		   map_of_cycles_and_frames.end(),
+		   back_inserter<vector<pair<int, std::vector<std::vector<unsigned char> > > > >(map_dumped_into_a_vector));
+	      
+	      int nframes=map_dumped_into_a_vector[0].second.size();
+	      if(_debug)   std::cout<<"storing cycleID:"<<map_dumped_into_a_vector[0].first<<" that has "<<nframes<<" nframes"<<endl;
+
+	      for(int jframes=0; jframes<nframes; jframes++) {
+		if(jframes==0) treeInit(zerosupression);
+		DecodeRawFrame(map_dumped_into_a_vector[0].second.at(jframes));
+		RecordCycle(zerosupression);
+		if(getbadbcid_bool==true) GetBadBCID();
+	      }
+	      tree->Fill();
+	      // }
+	      std::map<int, std::vector<std::vector<unsigned char>>>::iterator it;
+	      it=map_of_cycles_and_frames.find(map_dumped_into_a_vector[0].first);
+	      if (it != map_of_cycles_and_frames.end())
+		map_of_cycles_and_frames.erase(it++);
+	    } 
+	  }else{
+	    cout<<"WARNING NO TRAILER FOUND!"<<endl;
+	  }
+	}//header found
+      }//not eudaq
+      
+   
       trailerWord=0;
       if(initfilefound==true)
 	if(!fin.read((char *)&dataResult, sizeof(dataResult))) break;
       //}// no eudaq
 
       // fin.read((char *)&dataResult, sizeof(dataResult));
-  }
-  cout<<" ## END OF SLBrawROOT.cc converter : file: "<<inputFileName<<" TOTAL cycles:"<<totalcycles<<" cycles with data:"<<cycleswithdata<<endl;
-
-  fout->cd();
-  h1->Write();
-  h2->Write();
-  h3->Write();
-  h4->Write();
-  h5->Scale(1./consecevents);
-  h5->Write();
-  h6->Scale(1./nonconsecevents);
-  h6->Write();
-  h7->Write();
-  
-  fout->Write(0);
-  fout->Close();
-
-
-}
-
-//******************************************************************************************************************
-// ROOT PART
-void SLBraw2ROOT::Initialisation() {
-  fout->cd(); R2Rstate=-1;
-
-  tree = new TTree("siwecaldecoded","siwecaldecoded");
-
-  tree->Branch("event",&_event,"event/I");
-  tree->Branch("acqNumber",&_acqNumber,"acqNumber/I");
-  tree->Branch("n_slboards",&_n_slboards,"n_slboards/I");
-
-  TString name;
-  name= TString::Format("slot[%i]/I",SLBDEPTH);
-  tree->Branch("slot",_slot,name);
-  
-  name= TString::Format("slboard_id[%i]/I",SLBDEPTH);
-  tree->Branch("slboard_id",_slboard_id,name);
-  
-  name= TString::Format("chipid[%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU);
-  tree->Branch("chipid",_chipId,name);
-
-  name= TString::Format("nColumns[%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU);
-  tree->Branch("nColumns",_numCol,name);
-
-  name= TString::Format("startACQ[%i]/F",SLBDEPTH);
-  tree->Branch("startACQ",_startACQ,name);
-
-  name= TString::Format("rawTSD[%i]/I",SLBDEPTH);
-  tree->Branch("rawTSD",_rawTSD,name);
-
-  name= TString::Format("TSD[%i]/F",SLBDEPTH);
-  tree->Branch("TSD",_TSD,name);
-  
-  name= TString::Format("rawAVDD0[%i]/I",SLBDEPTH);
-  tree->Branch("rawAVDD0",_rawAVDD0,name);
-
-  name= TString::Format("rawAVDD1[%i]/I",SLBDEPTH);
-  tree->Branch("rawAVDD1",_rawAVDD1,name);
-
-  name= TString::Format("AVDD0[%i]/F",SLBDEPTH);
-  tree->Branch("AVDD0",_AVDD0,name);
-
-  name= TString::Format("AVDD1[%i]/F",SLBDEPTH);
-  tree->Branch("AVDD1",_AVDD1,name);
-  
-  name= TString::Format("bcid[%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC);
-  tree->Branch("bcid",_bcid,name);
-
-  name= TString::Format("corrected_bcid[%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC);
-  tree->Branch("corrected_bcid",_corrected_bcid,name);
-
-  name= TString::Format("badbcid[%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC);
-  tree->Branch("badbcid",_badbcid,name);
-
-  name= TString::Format("nhits[%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC);
-  tree->Branch("nhits",_nhits,name);
-
-  name= TString::Format("lowGain[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
-  tree->Branch("charge_lowGain",_charge_low,name);
-
-  name= TString::Format("highGain[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
-  tree->Branch("charge_hiGain",_charge_high,name);
-
-  name= TString::Format("gain_hit_low[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
-  tree->Branch("gain_hit_low",_gain_hit_low,name);
-
-  name= TString::Format("gain_hit_high[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
-  tree->Branch("gain_hit_high",_gain_hit_high,name);
-
-  return;
-}
-
-void SLBraw2ROOT::treeInit(bool zerosupression=false) { //init data for a single SPILL ?
-
-  for (int isl=0; isl<SLBDEPTH; isl++) {
-    for (int k=0; k<NB_OF_SKIROCS_PER_ASU; k++) {
-      for (int i=0; i<NB_OF_SCAS_IN_SKIROC; i++) {
-	_bcid[isl][k][i]=-999;
-	_badbcid[isl][k][i]=-999;
-	_corrected_bcid[isl][k][i]=-999;
-	_nhits[isl][k][i]=-999;
-	for (int j=0; j<NB_OF_CHANNELS_IN_SKIROC; j++) {
-	  _charge_low[isl][k][i][j]=-999;
-	  _charge_high[isl][k][i][j]=-999;
-	  _gain_hit_low[isl][k][i][j]=-999;
-	  _gain_hit_high[isl][k][i][j]=-999;
-	}
-      }
-      
-      _chipId[isl][k]=-999;
-      _numCol[isl][k]=0;
-      _startACQ[isl]=-1;
-      _rawTSD[isl]=-1;
-      _TSD[isl]=-1;
-      _rawAVDD0[isl]=-1;
-      _rawAVDD1[isl]=-1;
-      _AVDD0[isl]=-1;
-      _AVDD1[isl]=-1;
     }
-    _slot[isl]=-1;
-    _slboard_id[isl]=-1;
+
+    //save the remaining cycles
+    while(map_of_cycles_and_frames.size()> 0) {
+      cycleswithdata++;
+      //sorting the map
+      std::vector<pair<int, std::vector<std::vector<unsigned char> > > > map_dumped_into_a_vector;
+      copy(map_of_cycles_and_frames.begin(),
+    	 map_of_cycles_and_frames.end(),
+    	 back_inserter<vector<pair<int, std::vector<std::vector<unsigned char> > > > >(map_dumped_into_a_vector));
+      int nframes=map_dumped_into_a_vector[0].second.size();
+      if(_debug)   std::cout<<"storing cycleID:"<<map_dumped_into_a_vector[0].first<<" that has "<<nframes<<" nframes"<<endl;
+
+      for(int jframes=0; jframes<nframes; jframes++) {
+        DecodeRawFrame(map_dumped_into_a_vector[0].second.at(jframes));
+        if(jframes==0) treeInit(zerosupression);
+        RecordCycle(zerosupression);
+        if(getbadbcid_bool==true) GetBadBCID();
+        tree->Fill();
+      }
+      // }
+      std::map<int, std::vector<std::vector<unsigned char>>>::iterator it;
+      it=map_of_cycles_and_frames.find(map_dumped_into_a_vector[0].first);
+      if (it != map_of_cycles_and_frames.end())
+        map_of_cycles_and_frames.erase(it++);
+    }
+  
+    cout<<" ## END OF SLBrawROOT.cc converter : file: "<<inputFileName<<" FirstCycle:"<<firstcycleid<<" LastCycle:"<<lastcycleid<<" Total cycles with data:"<<cycleswithdata<<endl;
+
+    fout->cd();
+   
+    fout->Write(0);
+    fout->Close();
+
+
   }
-  _n_slboards=-1;
-  _acqNumber=-1;
 
-  return;
-}
+  //******************************************************************************************************************
+  // ROOT PART
+  void SLBraw2ROOT::Initialisation() {
+    fout->cd(); R2Rstate=-1;
 
+    tree = new TTree("siwecaldecoded","siwecaldecoded");
 
-void SLBraw2ROOT::GetBadBCID() {
+    tree->Branch("event",&_event,"event/I");
+    tree->Branch("acqNumber",&_acqNumber,"acqNumber/I");
+    tree->Branch("n_slboards",&_n_slboards,"n_slboards/I");
 
-  //add tags
-  //  int count_negdata[SLBDEPTH];
-  //  for(int i=0; i<SLBDEPTH; i++) count_negdata[i]=0;
+    TString name;
+    name= TString::Format("slot[%i]/I",SLBDEPTH);
+    tree->Branch("slot",_slot,name);
+  
+    name= TString::Format("slboard_id[%i]/I",SLBDEPTH);
+    tree->Branch("slboard_id",_slboard_id,name);
+  
+    name= TString::Format("chipid[%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU);
+    tree->Branch("chipid",_chipId,name);
 
-  for(int i=0; i<SLBDEPTH; i++) {
-  for (int k=0; k<NB_OF_SKIROCS_PER_ASU; k++) {
-    //only for valid chips in this spill
-    if (_chipId[i][k]>=0) {
-      for (int ibc=0; ibc<_numCol[i][k]; ibc++) {
+    name= TString::Format("nColumns[%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU);
+    tree->Branch("nColumns",_numCol,name);
 
-	// if sca+1 is filled with consec bcid, but sca+2 not, then _badbcid[sca]==1 && _badbcid[sca+1]==2 (bcid+1 issue, events are not _bad, just the next sca trigger is empty)
-	// if sca+1 is filled with consec bcid, and sca+2 also, then _badbcid[sca]==3 && _badbcid[sca+1]==3 (retriggering)
-	// if sca+1 is not filled with consec bcid,  _badbcid==0
+    name= TString::Format("startACQ[%i]/F",SLBDEPTH);
+    tree->Branch("startACQ",_startACQ,name);
 
-	if(ibc==0) {
-	  _badbcid[i][k][ibc]=0;
-	  int _corr_bcid=_corrected_bcid[i][k][ibc];
-	  int _corr_bcid1=0;
-	  int _corr_bcid2=0;
+    name= TString::Format("rawTSD[%i]/I",SLBDEPTH);
+    tree->Branch("rawTSD",_rawTSD,name);
 
-	  if(_corrected_bcid[i][k][ibc+1]>0 && _corrected_bcid[i][k][ibc]>0 && (_corrected_bcid[i][k][ibc+1]-_corrected_bcid[i][k][ibc])>0) 
-	    _corr_bcid1=_corrected_bcid[i][k][ibc+1];
+    name= TString::Format("TSD[%i]/F",SLBDEPTH);
+    tree->Branch("TSD",_TSD,name);
+  
+    name= TString::Format("rawAVDD0[%i]/I",SLBDEPTH);
+    tree->Branch("rawAVDD0",_rawAVDD0,name);
 
-	  if(_corrected_bcid[i][k][ibc+2]>0 && (_corrected_bcid[i][k][ibc+2]-_corrected_bcid[i][k][ibc+1])>0) 
-	    _corr_bcid2=_corrected_bcid[i][k][ibc+2];
+    name= TString::Format("rawAVDD1[%i]/I",SLBDEPTH);
+    tree->Branch("rawAVDD1",_rawAVDD1,name);
 
-	  if(_corr_bcid2>0) {
-	    //empty events
-	    if( ( _corr_bcid2-_corr_bcid1) >(BCIDTHRES - 1) && (_corr_bcid1-_corr_bcid) ==1) {
-	      _badbcid[i][k][ibc]=1;
-	      _badbcid[i][k][ibc+1]=2;
-	    }
-	    // pure retriggers
-	    if( ( _corr_bcid2-_corr_bcid1) < BCIDTHRES && (_corr_bcid1-_corr_bcid) < BCIDTHRES) {
-	      _badbcid[i][k][ibc]=3;
-	      _badbcid[i][k][ibc+1]=3;
-	      _badbcid[i][k][ibc+2]=3;
-	    }
-    	  }
+    name= TString::Format("AVDD0[%i]/F",SLBDEPTH);
+    tree->Branch("AVDD0",_AVDD0,name);
 
-	  if( _corr_bcid1 > 0 && (_corr_bcid1-_corr_bcid) > 1 && (_corr_bcid1-_corr_bcid) <BCIDTHRES) {
-	    _badbcid[i][k][ibc]=3;
-	    _badbcid[i][k][ibc+1]=3;
-	  }  
-	} //ibc==0 if 
+    name= TString::Format("AVDD1[%i]/F",SLBDEPTH);
+    tree->Branch("AVDD1",_AVDD1,name);
+  
+    name= TString::Format("bcid[%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC);
+    tree->Branch("bcid",_bcid,name);
 
-	if(ibc>0 && _badbcid[i][k][ibc]<0 && _corrected_bcid[i][k][ibc] >0 &&  (_corrected_bcid[i][k][ibc]-_corrected_bcid[i][k][ibc-1])>0 ) {
-	  _badbcid[i][k][ibc]=0;
-	  int _corr_bcid=_corrected_bcid[i][k][ibc];
-	  int _corr_bcidminus=_corrected_bcid[i][k][ibc-1];
+    name= TString::Format("corrected_bcid[%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC);
+    tree->Branch("corrected_bcid",_corrected_bcid,name);
 
-	  if(_corrected_bcid[i][k][ibc+1]>0 && (_corrected_bcid[i][k][ibc+1]-_corrected_bcid[i][k][ibc])>0) {
-	    int _corr_bcid1=_corrected_bcid[i][k][ibc+1];
+    name= TString::Format("badbcid[%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC);
+    tree->Branch("badbcid",_badbcid,name);
 
-	    if(_corrected_bcid[i][k][ibc+2]>0 && (_corrected_bcid[i][k][ibc+2]-_corrected_bcid[i][k][ibc+1])>0) {
-	      int _corr_bcid2=_corrected_bcid[i][k][ibc+2];
-	      if( ( _corr_bcid2-_corr_bcid1) < BCIDTHRES && (_corr_bcid1-_corr_bcid) < BCIDTHRES) {
+    name= TString::Format("nhits[%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC);
+    tree->Branch("nhits",_nhits,name);
+
+    name= TString::Format("lowGain[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
+    tree->Branch("charge_lowGain",_charge_low,name);
+
+    name= TString::Format("highGain[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
+    tree->Branch("charge_hiGain",_charge_high,name);
+
+    name= TString::Format("gain_hit_low[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
+    tree->Branch("gain_hit_low",_gain_hit_low,name);
+
+    name= TString::Format("gain_hit_high[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
+    tree->Branch("gain_hit_high",_gain_hit_high,name);
+
+    return;
+  }
+
+  void SLBraw2ROOT::treeInit(bool zerosupression=false) { //init data for a single SPILL ?
+
+    for (int isl=0; isl<SLBDEPTH; isl++) {
+      for (int k=0; k<NB_OF_SKIROCS_PER_ASU; k++) {
+	for (int i=0; i<NB_OF_SCAS_IN_SKIROC; i++) {
+	  _bcid[isl][k][i]=-999;
+	  _badbcid[isl][k][i]=-999;
+	  _corrected_bcid[isl][k][i]=-999;
+	  _nhits[isl][k][i]=-999;
+	  for (int j=0; j<NB_OF_CHANNELS_IN_SKIROC; j++) {
+	    _charge_low[isl][k][i][j]=-999;
+	    _charge_high[isl][k][i][j]=-999;
+	    _gain_hit_low[isl][k][i][j]=-999;
+	    _gain_hit_high[isl][k][i][j]=-999;
+	  }
+	}
+      
+	_chipId[isl][k]=-999;
+	_numCol[isl][k]=0;
+	_startACQ[isl]=-1;
+	_rawTSD[isl]=-1;
+	_TSD[isl]=-1;
+	_rawAVDD0[isl]=-1;
+	_rawAVDD1[isl]=-1;
+	_AVDD0[isl]=-1;
+	_AVDD1[isl]=-1;
+      }
+      _slot[isl]=-1;
+      _slboard_id[isl]=-1;
+    }
+    _n_slboards=-1;
+    _acqNumber=-1;
+
+    return;
+  }
+
+  void SLBraw2ROOT::RecordCycle(bool zerosupression=false) {
+    _acqNumber=cycleID;
+    _n_slboards=SLBDEPTH;
+    int previousBCID=-1000;
+    int loopBCID=0;
+  
+    _startACQ[slabAdd]=startAcqTimeStamp;
+    _rawTSD[slabAdd]=rawTSD;
+    _TSD[slabAdd]=temperature;
+    _rawAVDD0[slabAdd]=rawAVDD0;
+    _rawAVDD1[slabAdd]=rawAVDD1;
+    _AVDD0[slabAdd]=AVDD0;
+    _AVDD1[slabAdd]=AVDD1;
+  
+    _slot[slabAdd]=-1;//we don't know this information... the DQ only provides addresses.
+    _slboard_id[slabAdd]=slabAdd;
+  
+    for(int isca=0; isca<nbOfSingleSkirocEventsInFrame; isca++) {
+      _bcid[slabAdd][chipId][isca]=bcid[isca];
+      _nhits[slabAdd][chipId][isca]=nhits[isca];
+      _numCol[slabAdd][chipId]=isca+1;
+      if(_bcid[slabAdd][chipId][isca] > 0 && _bcid[slabAdd][chipId][isca]-previousBCID < 0) loopBCID++;
+      if(_bcid[slabAdd][chipId][isca] > 0 ) _corrected_bcid[slabAdd][chipId][isca] = _bcid[slabAdd][chipId][isca]+loopBCID*4096;
+      previousBCID=bcid[isca];
+    
+      if(chipId>-1 && chipId<16) {
+	_chipId[slabAdd][chipId]=chipId;
+      } else {
+	cout<<"Wrong chipId = "<<chipId<<endl;
+	break;
+      }
+      int nchn=0;
+      if(zerosupression==false) nchn=NB_OF_CHANNELS_IN_SKIROC;
+      else nchn = nhits[isca];
+      for(int ichn=0; ichn<nchn; ichn++) {
+	_charge_low[slabAdd][chipId][isca][ichn]=chargevalue_low[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
+	_gain_hit_low[slabAdd][chipId][isca][ichn]=hitvalue_low[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
+	_charge_high[slabAdd][chipId][isca][ichn]=chargevalue_high[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
+	_gain_hit_high[slabAdd][chipId][isca][ichn]=hitvalue_high[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
+      }
+    }//end isca
+  }
+ 
+  void SLBraw2ROOT::GetBadBCID() {
+
+    //add tags
+    //  int count_negdata[SLBDEPTH];
+    //  for(int i=0; i<SLBDEPTH; i++) count_negdata[i]=0;
+
+    for(int i=0; i<SLBDEPTH; i++) {
+      for (int k=0; k<NB_OF_SKIROCS_PER_ASU; k++) {
+	//only for valid chips in this spill
+	if (_chipId[i][k]>=0) {
+	  for (int ibc=0; ibc<_numCol[i][k]; ibc++) {
+
+	    // if sca+1 is filled with consec bcid, but sca+2 not, then _badbcid[sca]==1 && _badbcid[sca+1]==2 (bcid+1 issue, events are not _bad, just the next sca trigger is empty)
+	    // if sca+1 is filled with consec bcid, and sca+2 also, then _badbcid[sca]==3 && _badbcid[sca+1]==3 (retriggering)
+	    // if sca+1 is not filled with consec bcid,  _badbcid==0
+
+	    if(ibc==0) {
+	      _badbcid[i][k][ibc]=0;
+	      int _corr_bcid=_corrected_bcid[i][k][ibc];
+	      int _corr_bcid1=0;
+	      int _corr_bcid2=0;
+
+	      if(_corrected_bcid[i][k][ibc+1]>0 && _corrected_bcid[i][k][ibc]>0 && (_corrected_bcid[i][k][ibc+1]-_corrected_bcid[i][k][ibc])>0) 
+		_corr_bcid1=_corrected_bcid[i][k][ibc+1];
+
+	      if(_corrected_bcid[i][k][ibc+2]>0 && (_corrected_bcid[i][k][ibc+2]-_corrected_bcid[i][k][ibc+1])>0) 
+		_corr_bcid2=_corrected_bcid[i][k][ibc+2];
+
+	      if(_corr_bcid2>0) {
+		//empty events
+		if( ( _corr_bcid2-_corr_bcid1) >(BCIDTHRES - 1) && (_corr_bcid1-_corr_bcid) ==1) {
+		  _badbcid[i][k][ibc]=1;
+		  _badbcid[i][k][ibc+1]=2;
+		}
+		// pure retriggers
+		if( ( _corr_bcid2-_corr_bcid1) < BCIDTHRES && (_corr_bcid1-_corr_bcid) < BCIDTHRES) {
+		  _badbcid[i][k][ibc]=3;
+		  _badbcid[i][k][ibc+1]=3;
+		  _badbcid[i][k][ibc+2]=3;
+		}
+	      }
+
+	      if( _corr_bcid1 > 0 && (_corr_bcid1-_corr_bcid) > 1 && (_corr_bcid1-_corr_bcid) <BCIDTHRES) {
 		_badbcid[i][k][ibc]=3;
 		_badbcid[i][k][ibc+1]=3;
-		_badbcid[i][k][ibc+2]=3;
-	      }
-	      if( (_corr_bcid1-_corr_bcid) < BCIDTHRES && (_corr_bcid-_corr_bcidminus) < BCIDTHRES ) _badbcid[i][k][ibc]=3;
+	      }  
+	    } //ibc==0 if 
 
-	      if( _badbcid[i][k][ibc]!=3 && ( _corr_bcid2-_corr_bcid1) >(BCIDTHRES - 1) && (_corr_bcid1-_corr_bcid) ==1) {
-		_badbcid[i][k][ibc]=1;
-		_badbcid[i][k][ibc+1]=2;
-	      }
-	      if( _badbcid[i][k][ibc]!=3 && ( _corr_bcid2-_corr_bcid1) >(BCIDTHRES - 1) && (_corr_bcid1-_corr_bcid) > 1 && (_corr_bcid1-_corr_bcid) <BCIDTHRES) {
-		_badbcid[i][k][ibc]=3;
-		_badbcid[i][k][ibc+1]=3;
-	      }
-	      if( (_corr_bcid-_corr_bcidminus) < BCIDTHRES ) _badbcid[i][k][ibc]=3;
+	    if(ibc>0 && _badbcid[i][k][ibc]<0 && _corrected_bcid[i][k][ibc] >0 &&  (_corrected_bcid[i][k][ibc]-_corrected_bcid[i][k][ibc-1])>0 ) {
+	      _badbcid[i][k][ibc]=0;
+	      int _corr_bcid=_corrected_bcid[i][k][ibc];
+	      int _corr_bcidminus=_corrected_bcid[i][k][ibc-1];
 
-	      //if( _badbcid[i][k][ibc-1]==1 && (_corr_bcid1-_corr_bcid) > (BCIDTHRES - 1)) _badbcid[i][k][ibc]=2;
-	    } else {
-	      if( (_corr_bcid1-_corr_bcid) < BCIDTHRES ) _badbcid[i][k][ibc]=3;
-	      if( (_corr_bcid-_corr_bcidminus) < BCIDTHRES ) _badbcid[i][k][ibc]=3;
-	    } //ibc+2 if
-	  } else {
-	    if( (_corr_bcid-_corr_bcidminus) < BCIDTHRES ) _badbcid[i][k][ibc]=3;
-	  }//ibc+1 if
-	} //ibc>0 if 
+	      if(_corrected_bcid[i][k][ibc+1]>0 && (_corrected_bcid[i][k][ibc+1]-_corrected_bcid[i][k][ibc])>0) {
+		int _corr_bcid1=_corrected_bcid[i][k][ibc+1];
+
+		if(_corrected_bcid[i][k][ibc+2]>0 && (_corrected_bcid[i][k][ibc+2]-_corrected_bcid[i][k][ibc+1])>0) {
+		  int _corr_bcid2=_corrected_bcid[i][k][ibc+2];
+		  if( ( _corr_bcid2-_corr_bcid1) < BCIDTHRES && (_corr_bcid1-_corr_bcid) < BCIDTHRES) {
+		    _badbcid[i][k][ibc]=3;
+		    _badbcid[i][k][ibc+1]=3;
+		    _badbcid[i][k][ibc+2]=3;
+		  }
+		  if( (_corr_bcid1-_corr_bcid) < BCIDTHRES && (_corr_bcid-_corr_bcidminus) < BCIDTHRES ) _badbcid[i][k][ibc]=3;
+
+		  if( _badbcid[i][k][ibc]!=3 && ( _corr_bcid2-_corr_bcid1) >(BCIDTHRES - 1) && (_corr_bcid1-_corr_bcid) ==1) {
+		    _badbcid[i][k][ibc]=1;
+		    _badbcid[i][k][ibc+1]=2;
+		  }
+		  if( _badbcid[i][k][ibc]!=3 && ( _corr_bcid2-_corr_bcid1) >(BCIDTHRES - 1) && (_corr_bcid1-_corr_bcid) > 1 && (_corr_bcid1-_corr_bcid) <BCIDTHRES) {
+		    _badbcid[i][k][ibc]=3;
+		    _badbcid[i][k][ibc+1]=3;
+		  }
+		  if( (_corr_bcid-_corr_bcidminus) < BCIDTHRES ) _badbcid[i][k][ibc]=3;
+
+		  //if( _badbcid[i][k][ibc-1]==1 && (_corr_bcid1-_corr_bcid) > (BCIDTHRES - 1)) _badbcid[i][k][ibc]=2;
+		} else {
+		  if( (_corr_bcid1-_corr_bcid) < BCIDTHRES ) _badbcid[i][k][ibc]=3;
+		  if( (_corr_bcid-_corr_bcidminus) < BCIDTHRES ) _badbcid[i][k][ibc]=3;
+		} //ibc+2 if
+	      } else {
+		if( (_corr_bcid-_corr_bcidminus) < BCIDTHRES ) _badbcid[i][k][ibc]=3;
+	      }//ibc+1 if
+	    } //ibc>0 if 
 
       
-	//tag zero (under/over flow) data
-	//	count_negdata=0;
+	    //tag zero (under/over flow) data
+	    //	count_negdata=0;
 	
-	//	for (int ichan=0; ichan<NB_OF_CHANNELS_IN_SKIROC; ichan++) {
-	//  if  (charge_high[i][k][ibc][ichan] < NEGDATA_THR) count_negdata++;
-	//}//ichan
+	    //	for (int ichan=0; ichan<NB_OF_CHANNELS_IN_SKIROC; ichan++) {
+	    //  if  (charge_high[i][k][ibc][ichan] < NEGDATA_THR) count_negdata++;
+	    //}//ichan
 
-	//if (count_negdata>0) {_badbcid[i][k][ibc]+=32;}
+	    //if (count_negdata>0) {_badbcid[i][k][ibc]+=32;}
 
-      }//ibc
+	  }//ibc
 
-    }//chipId
-  }//k
-  }//i   slboard
+	}//chipId
+      }//k
+    }//i   slboard
   
-}
+  }
 
 
 

--- a/converter_SLB/SLBraw2ROOT.cc
+++ b/converter_SLB/SLBraw2ROOT.cc
@@ -72,7 +72,7 @@ public:
     _ASCIIOUT = false;
     _debug = false;
     _debug2 = false;
-    _eudaq=false;
+    _eudaq= false;
     _maxReadOutCycleJump=10;
   }
   ~SLBraw2ROOT(){

--- a/converter_SLB/SLBraw2ROOT.cc
+++ b/converter_SLB/SLBraw2ROOT.cc
@@ -44,21 +44,13 @@ int	Convert_FromGrayToBinary (int grayValue, int nbOfBits)
   int binary, grayBit, binBit;
 	
   binary = 0;
-
   // mask the MSB.
-	
   grayBit = 1 << ( nbOfBits - 1 );
-	
   // copy the MSB.
-	
   binary = grayValue & grayBit;
-	
   // store the bit we just set.
-	
   binBit = binary;
-	
   // traverse remaining Gray bits.
-	
   while( grayBit >>= 1 )
     {
       // shift the current binary bit to align with the Gray bit.
@@ -76,7 +68,7 @@ class SLBraw2ROOT {
   
 public:
   SLBraw2ROOT(){
-    _ASCIIOUT = false;
+    _ASCIIOUT = true;
     _debug = false;
     _eudaq=false;
   }
@@ -216,7 +208,6 @@ void SLBraw2ROOT::InitializeRawFrame() {
 }
 
 void SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
-  if(_ASCIIOUT)cout<<" New DECODERAWFRAME "<<endl;
   chipId = ucharValFrameVec.at(datasize -2-2);
   if(_debug) std::cout<<"chipId:"<<dec<<chipId<<std::endl;
   if(_debug) std::cout<<"AsuIndex:"<<dec<<(int)(chipId/NB_OF_SKIROCS_PER_ASU)<<std::endl;
@@ -244,7 +235,7 @@ void SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
       cycleID += ((unsigned int)(((ucharValFrameVec.at(2*n+1)& 0xC0)>> 6) << (30-2*i)));
       i++;
     }
-      if(_debug) std::cout<<"cycleID:"<<dec<<cycleID<<std::endl;
+  if(_debug) std::cout<<"cycleID:"<<dec<<cycleID<<std::endl;
 	    
   i=0;
   for(n= 16; n < 32; n++)
@@ -413,7 +404,7 @@ void SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
   TH1F * h3 = new TH1F("size_event","Size event (total); Total Number of words; entries",100,0,500);
   TH2F * h4 = new TH2F("size_vs_cyclerates","Ocuppancy ; cycleID-previousCycleID; Eventsize previous event",100,-0.5,99.5,100,0,500);
   TH2F * h5 = new TH2F("size_consecutivecyclces","Eventsize previous event (DeltaCycle=1) ; ASIC ; LAYER",16,-0.5,15.5,15,-0.5,14.5);
-  TH2F * h6 = new TH2F("size_nonconsecutivecyclces","Eventsize previous event (DeltaCycle>4) ; ASIC ; LAYER",16,-0.5,15.5,15,-0.5,14.5);
+  TH2F * h6 = new TH2F("size_nonconsecutivecyclces","Eventsize previous event (DeltaCycle>1) ; ASIC ; LAYER",16,-0.5,15.5,15,-0.5,14.5);
   TH1F * h7 = new TH1F("wrongly_reconstructed_cycles","wrongly_reconstructed_cycles",4320000,0.5,4320000.5);
   int event_size=0;
   int event_size_prev=0;
@@ -569,7 +560,7 @@ void SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
 		  h5->Fill(j,i,max_event_size_prev[i][j]);
 		  consecevents++;
 		}
-		if( (cycleID-previouscycle)>4) {
+		if( (cycleID-previouscycle)>1) {
 		  h6->Fill(j,i,max_event_size_prev[i][j]);
 		  nonconsecevents++;
 		}

--- a/converter_SLB/SLBraw2ROOT.cc
+++ b/converter_SLB/SLBraw2ROOT.cc
@@ -148,9 +148,11 @@ protected:
   int _nhits[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC];
   int _charge_low[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
   int _charge_high[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
-  int _gain_hit_low[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
-  int _gain_hit_high[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
-  int _event;
+  int _autogainbit_low[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
+  int _autogainbit_high[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
+  int _hitbit_low[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
+  int _hitbit_high[SLBDEPTH][NB_OF_SKIROCS_PER_ASU][NB_OF_SCAS_IN_SKIROC][NB_OF_CHANNELS_IN_SKIROC];
+  //  int _event;
   //int numbcid;
   int _numCol[SLBDEPTH][NB_OF_SKIROCS_PER_ASU];
   int _chipId[SLBDEPTH][NB_OF_SKIROCS_PER_ASU];
@@ -393,8 +395,8 @@ void SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
 	}
 				
       index += (NB_OF_CHANNELS_IN_SKIROC*2);
-      if((nbOfSingleSkirocEventsInFrame-sca_ascii-1) == 0)
-	_event++;
+      //      if((nbOfSingleSkirocEventsInFrame-sca_ascii-1) == 0)
+      //	_event++;
 
       if(_ASCIIOUT){
 	//#0 Size 1 ChipID 9 coreIdx 0 slabIdx 0 slabAdd 0 Asu 0 SkirocIndex 9 transmitID 0 cycleID 2 StartTime 56717 rawTSD 3712 rawAVDD0 2017 rawAVDD1 2023 tsdValue 36.02 avDD0 1.971 aVDD1 1.977
@@ -421,7 +423,7 @@ bool SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
  
     ifstream fin;
     unsigned int dataResult=0;
-    _event=0;
+    //    _event=0;
     _acqNumber=0;
   
     if(outFileName == "default"){
@@ -671,7 +673,7 @@ bool SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
 
     tree = new TTree("siwecaldecoded","siwecaldecoded");
 
-    tree->Branch("event",&_event,"event/I");
+    //    tree->Branch("event",&_event,"event/I");
     tree->Branch("acqNumber",&_acqNumber,"acqNumber/I");
     tree->Branch("n_slboards",&_n_slboards,"n_slboards/I");
 
@@ -727,11 +729,17 @@ bool SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
     name= TString::Format("highGain[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
     tree->Branch("charge_hiGain",_charge_high,name);
 
-    name= TString::Format("gain_hit_low[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
-    tree->Branch("gain_hit_low",_gain_hit_low,name);
+    name= TString::Format("autogainbit_low[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
+    tree->Branch("autogainbit_low",_autogainbit_low,name);
 
-    name= TString::Format("gain_hit_high[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
-    tree->Branch("gain_hit_high",_gain_hit_high,name);
+    name= TString::Format("autogainbit_high[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
+    tree->Branch("autogainbit_high",_autogainbit_high,name);
+    
+    name= TString::Format("hitbit_low[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
+    tree->Branch("hitbit_low",_hitbit_low,name);
+
+    name= TString::Format("hitbit_high[%i][%i][%i][%i]/I",SLBDEPTH,NB_OF_SKIROCS_PER_ASU,NB_OF_SCAS_IN_SKIROC,NB_OF_CHANNELS_IN_SKIROC);
+    tree->Branch("hitbit_high",_hitbit_high,name);
 
     return;
   }
@@ -748,8 +756,11 @@ bool SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
 	  for (int j=0; j<NB_OF_CHANNELS_IN_SKIROC; j++) {
 	    _charge_low[isl][k][i][j]=-999;
 	    _charge_high[isl][k][i][j]=-999;
-	    _gain_hit_low[isl][k][i][j]=-999;
-	    _gain_hit_high[isl][k][i][j]=-999;
+	    _autogainbit_low[isl][k][i][j]=-999;
+	    _autogainbit_high[isl][k][i][j]=-999;
+	     _hitbit_low[isl][k][i][j]=-999;
+            _hitbit_high[isl][k][i][j]=-999;
+
 	  }
 	}
       
@@ -808,9 +819,12 @@ bool SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
       else nchn = nhits[isca];
       for(int ichn=0; ichn<nchn; ichn++) {
 	_charge_low[slabAdd][chipId][isca][ichn]=chargevalue_low[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
-	_gain_hit_low[slabAdd][chipId][isca][ichn]=hitvalue_low[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
+	_autogainbit_low[slabAdd][chipId][isca][ichn]=gainvalue_low[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
+	_hitbit_low[slabAdd][chipId][isca][ichn]=hitvalue_low[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
 	_charge_high[slabAdd][chipId][isca][ichn]=chargevalue_high[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
-	_gain_hit_high[slabAdd][chipId][isca][ichn]=hitvalue_high[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
+	_hitbit_high[slabAdd][chipId][isca][ichn]=gainvalue_high[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
+	_autogainbit_high[slabAdd][chipId][isca][ichn]=hitvalue_high[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
+	
       }
     }//end isca
   }

--- a/converter_SLB/SLBraw2ROOT.cc
+++ b/converter_SLB/SLBraw2ROOT.cc
@@ -375,8 +375,8 @@ bool SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
 	  
 	  rawData = (unsigned short)ucharValFrameVec.at(index+2*channel) + ((unsigned short)ucharValFrameVec.at(index+1+2*channel) << 8);
 	  rawValue = (int)(rawData & 0xFFF);
-	  hitvalue_high[sca][channel] =  (rawData & 0x1000)>>12;
-	  gainvalue_high[sca][channel] =  (rawData & 0x2000)>>13;
+	  gainalue_high[sca][channel] =  (rawData & 0x1000)>>12;
+	  hitvalue_high[sca][channel] =  (rawData & 0x2000)>>13;
 	  int chargeValuetemp =  Convert_FromGrayToBinary(rawValue , 12); 
 	  chargevalue_high[sca][channel] = chargeValuetemp;
 	  if(_debug) std::cout<<"chn:"<<channel<<" gainvalue_1:"<<gainvalue_high[sca][channel]<<" hitvalue_1:"<<hitvalue_high[sca][channel]<<" "<<"chargeValue_1:"<<chargevalue_high[sca][channel]<<std::endl;
@@ -391,8 +391,8 @@ bool SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
 	  if(_debug) std::cout<<"chn:"<<channel<<endl;
 	  rawData = (unsigned short)ucharValFrameVec.at(index+2*channel) + ((unsigned short)ucharValFrameVec.at(index+1+2*channel) << 8);
 	  rawValue = (int)(rawData & 0xFFF);
-	  hitvalue_low[sca][channel] =  (rawData & 0x1000)>>12;
-	  gainvalue_low[sca][channel] =  (rawData & 0x2000)>>13;  
+	  gainvalue_low[sca][channel] =  (rawData & 0x1000)>>12;
+	  hitvalue_low[sca][channel] =  (rawData & 0x2000)>>13;  
 	  int chargeValuetemp = Convert_FromGrayToBinary(rawValue , 12);
 	  chargevalue_low[sca][channel] = chargeValuetemp;
 	  if(_debug) std::cout<<"chn:"<<channel<<" gainvalue_0:"<<gainvalue_low[sca][channel]<<" hitvalue_0:"<<hitvalue_low[sca][channel]<<" "<<"chargeValue_0:"<<chargevalue_low[sca][channel]<<std::endl;

--- a/converter_SLB/SLBraw2ROOT.cc
+++ b/converter_SLB/SLBraw2ROOT.cc
@@ -375,8 +375,8 @@ bool SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
 	  
 	  rawData = (unsigned short)ucharValFrameVec.at(index+2*channel) + ((unsigned short)ucharValFrameVec.at(index+1+2*channel) << 8);
 	  rawValue = (int)(rawData & 0xFFF);
-	  gainvalue_high[sca][channel] =  (rawData & 0x1000)>>12;
-	  hitvalue_high[sca][channel] =  (rawData & 0x2000)>>13;
+	  hitvalue_high[sca][channel] =  (rawData & 0x1000)>>12;
+	  gainvalue_high[sca][channel] =  (rawData & 0x2000)>>13;
 	  int adcValuetemp =  Convert_FromGrayToBinary(rawValue , 12); 
 	  adcvalue_high[sca][channel] = adcValuetemp;
 	  if(_debug) std::cout<<"chn:"<<channel<<" gainvalue_1:"<<gainvalue_high[sca][channel]<<" hitvalue_1:"<<hitvalue_high[sca][channel]<<" "<<"adcValue_1:"<<adcvalue_high[sca][channel]<<std::endl;
@@ -391,8 +391,8 @@ bool SLBraw2ROOT::DecodeRawFrame(std::vector<unsigned char> ucharValFrameVec ) {
 	  if(_debug) std::cout<<"chn:"<<channel<<endl;
 	  rawData = (unsigned short)ucharValFrameVec.at(index+2*channel) + ((unsigned short)ucharValFrameVec.at(index+1+2*channel) << 8);
 	  rawValue = (int)(rawData & 0xFFF);
-	  gainvalue_low[sca][channel] =  (rawData & 0x1000)>>12;
-	  hitvalue_low[sca][channel] =  (rawData & 0x2000)>>13;  
+	  hitvalue_low[sca][channel] =  (rawData & 0x1000)>>12;
+	  gainvalue_low[sca][channel] =  (rawData & 0x2000)>>13;  
 	  int adcValuetemp = Convert_FromGrayToBinary(rawValue , 12);
 	  adcvalue_low[sca][channel] = adcValuetemp;
 	  if(_debug) std::cout<<"chn:"<<channel<<" gainvalue_0:"<<gainvalue_low[sca][channel]<<" hitvalue_0:"<<hitvalue_low[sca][channel]<<" "<<"adcValue_0:"<<adcvalue_low[sca][channel]<<std::endl;
@@ -830,8 +830,8 @@ bool SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
 	_autogainbit_low[slabAdd][chipId][isca][ichn]=gainvalue_low[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
 	_hitbit_low[slabAdd][chipId][isca][ichn]=hitvalue_low[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
 	_adc_high[slabAdd][chipId][isca][ichn]=adcvalue_high[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
-	_hitbit_high[slabAdd][chipId][isca][ichn]=gainvalue_high[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
-	_autogainbit_high[slabAdd][chipId][isca][ichn]=hitvalue_high[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
+	_hitbit_high[slabAdd][chipId][isca][ichn]=hitvalue_high[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
+	_autogainbit_high[slabAdd][chipId][isca][ichn]=gainvalue_high[isca][NB_OF_CHANNELS_IN_SKIROC-ichn-1];
 	
       }
     }//end isca
@@ -853,7 +853,7 @@ bool SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
 	    // if sca+1 is not filled with consec bcid,  _badbcid==0
 	    // if sca and sca+1 have consecutive bcids but are not retriggers, then we consider 3 types of EMPTY events
 	    //     case A: empty events after a event with triggers
-	    //     case B: empty events before a event with triggers --> TO BE UNDERSTOOD but it seems that the good one is the one without the trigger (the first)
+	    //     case B: empty events before a event with triggers --> TO BE UNDERSTOOD but it seems that the good one is the one with the trigger (the second)
 	    //     case C&D: both bcids have triggers but, we do nothing
 	    
 	    if(ibc==0) {
@@ -876,10 +876,10 @@ bool SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
 		    _badbcid[i][k][ibc]=0;
 		    _badbcid[i][k][ibc+1]=2;//this one is to not be used in any case
 		  }
-		  //case B: empty events before a event with triggers --> TO BE UNDERSTOOD but it seems that the good one is the one without the trigger (the first)
+		  //case B: empty events before a event with triggers --> TO BE UNDERSTOOD but it seems that the good one is the one with trigger (the second bcid)
 		  if(_nhits[i][k][ibc]==0 && _nhits[i][k][ibc+1]>0) {
-		    _badbcid[i][k][ibc]=1; //this one should be used but it contains no info about the cells that were retriggered
-		    _badbcid[i][k][ibc+1]=2;//this one is to not be used
+		    _badbcid[i][k][ibc]=1; //empty event
+		    _badbcid[i][k][ibc+1]=0;//good one
 		  }
 		  //case C&D: both bcids have triggers but, we do nothing
 		}
@@ -921,10 +921,10 @@ bool SLBraw2ROOT::ReadFile(TString inputFileName, bool overwrite=false, TString 
 		      _badbcid[i][k][ibc]=0;
 		      _badbcid[i][k][ibc+1]=2;//this one is to not be used in any case
 		    }
-		    //case B: empty events before a event with triggers --> TO BE UNDERSTOOD but it seems that the good one is the one without the trigger (the first)
+		    //case B: empty events before a event with triggers --> TO BE UNDERSTOOD but it seems that the good one is the one with the trgger (the second bcid)
 		    if(_nhits[i][k][ibc]==0 && _nhits[i][k][ibc+1]>0) {
-		      _badbcid[i][k][ibc]=1; //this one should be used but it contains no info about the cells that were retriggered
-		      _badbcid[i][k][ibc+1]=2;//this one is to not be used
+		      _badbcid[i][k][ibc]=1; //empty event before the real event
+		      _badbcid[i][k][ibc+1]=0;//good event
 		    }
 		    //case C&D: both bcids have triggers: we do nothing
 		  }

--- a/include/siwecaldecoded.h
+++ b/include/siwecaldecoded.h
@@ -46,8 +46,8 @@ Int_t           bcid[15][16][15];
 Int_t           corrected_bcid[15][16][15];
 Int_t           badbcid[15][16][15];
 Int_t           nhits[15][16][15];
-Int_t           charge_lowGain[15][16][15][64];
-Int_t           charge_hiGain[15][16][15][64];
+Int_t           adc_low[15][16][15][64];
+Int_t           adc_high[15][16][15][64];
 Int_t           autogainbit_low[15][16][15][64];
 Int_t           autogainbit_high[15][16][15][64];
 Int_t           hitbit_low[15][16][15][64];
@@ -72,8 +72,8 @@ TBranch        *b_bcid;   //!
 TBranch        *b_corrected_bcid;   //!
 TBranch        *b_badbcid;   //!
 TBranch        *b_nhits;   //!
-TBranch        *b_lowGain;   //!
-TBranch        *b_highGain;   //!
+TBranch        *b_adc_low;   //!
+TBranch        *b_adc_high;   //!
 TBranch        *b_autogainbit_low;   //!
 TBranch        *b_autogainbit_high;   //!
 TBranch        *b_hitbit_low;   //!
@@ -99,8 +99,8 @@ void SetBranchAddressFunction(TTree *fChain) {
   fChain->SetBranchAddress("corrected_bcid", corrected_bcid, &b_corrected_bcid);
   fChain->SetBranchAddress("badbcid", badbcid, &b_badbcid);
   fChain->SetBranchAddress("nhits", nhits, &b_nhits);
-  fChain->SetBranchAddress("charge_lowGain", charge_lowGain, &b_lowGain);
-  fChain->SetBranchAddress("charge_hiGain", charge_hiGain, &b_highGain);
+  fChain->SetBranchAddress("adc_low", adc_low, &b_adc_low);
+  fChain->SetBranchAddress("adc_high", adc_high, &b_adc_high);
   fChain->SetBranchAddress("autogainbit_low", autogainbit_low, &b_autogainbit_low);
   fChain->SetBranchAddress("autogainbit_high", autogainbit_high, &b_autogainbit_high);
   fChain->SetBranchAddress("hitbit_low", hitbit_low, &b_hitbit_low);

--- a/include/siwecaldecoded.h
+++ b/include/siwecaldecoded.h
@@ -28,7 +28,7 @@ int slboard_array_mapping[15]={-1};
 
 
 // Declaration of leaf types
-Int_t           event;
+//Int_t           event;
 Int_t           acqNumber;
 Int_t           n_slboards;
 Int_t           slot[15];
@@ -48,11 +48,13 @@ Int_t           badbcid[15][16][15];
 Int_t           nhits[15][16][15];
 Int_t           charge_lowGain[15][16][15][64];
 Int_t           charge_hiGain[15][16][15][64];
-Int_t           gain_hit_low[15][16][15][64];
-Int_t           gain_hit_high[15][16][15][64];
+Int_t           autogainbit_low[15][16][15][64];
+Int_t           autogainbit_high[15][16][15][64];
+Int_t           hitbit_low[15][16][15][64];
+Int_t           hitbit_high[15][16][15][64];
 
 // List of branches
-TBranch        *b_event;   //!
+//TBranch        *b_event;   //!
 TBranch        *b_acqNumber;   //!
 TBranch        *b_n_slboards;   //!
 TBranch        *b_slot;   //!
@@ -72,12 +74,14 @@ TBranch        *b_badbcid;   //!
 TBranch        *b_nhits;   //!
 TBranch        *b_lowGain;   //!
 TBranch        *b_highGain;   //!
-TBranch        *b_gain_hit_low;   //!
-TBranch        *b_gain_hit_high;   //!
+TBranch        *b_autogainbit_low;   //!
+TBranch        *b_autogainbit_high;   //!
+TBranch        *b_hitbit_low;   //!
+TBranch        *b_hitbit_high;   //!
 
 
 void SetBranchAddressFunction(TTree *fChain) {
-  fChain->SetBranchAddress("event", &event, &b_event);
+  //  fChain->SetBranchAddress("event", &event, &b_event);
   fChain->SetBranchAddress("acqNumber", &acqNumber, &b_acqNumber);
   fChain->SetBranchAddress("n_slboards", &n_slboards, &b_n_slboards);
   fChain->SetBranchAddress("slot", slot, &b_slot);
@@ -97,7 +101,9 @@ void SetBranchAddressFunction(TTree *fChain) {
   fChain->SetBranchAddress("nhits", nhits, &b_nhits);
   fChain->SetBranchAddress("charge_lowGain", charge_lowGain, &b_lowGain);
   fChain->SetBranchAddress("charge_hiGain", charge_hiGain, &b_highGain);
-  fChain->SetBranchAddress("gain_hit_low", gain_hit_low, &b_gain_hit_low);
-  fChain->SetBranchAddress("gain_hit_high", gain_hit_high, &b_gain_hit_high);
+  fChain->SetBranchAddress("autogainbit_low", autogainbit_low, &b_autogainbit_low);
+  fChain->SetBranchAddress("autogainbit_high", autogainbit_high, &b_autogainbit_high);
+  fChain->SetBranchAddress("hitbit_low", hitbit_low, &b_hitbit_low);
+  fChain->SetBranchAddress("hitbit_high", hitbit_high, &b_hitbit_high);
   // Notify();
 }

--- a/include/utils.h
+++ b/include/utils.h
@@ -5,7 +5,6 @@
 //#include <bits/stdc++.h>
 
 
-
 int SimpleCoincidenceTagger(int ilayer, int maxnhit=5, int bcid_ref=0){
 
   int bcid_seen=0;
@@ -295,6 +294,7 @@ void ReadPedestalsProtoCovariance(TString filename)
   for(int islboard=0; islboard<15; islboard++) {
     std::vector<std::vector<std::vector<Double_t> > > chip_ped_mean_slb;
     std::vector<std::vector<std::vector<Double_t> > > chip_ped_w_i_slb;
+    std::vector<std::vector<std::vector<Double_t> > > chip_ped_error_slb;
     std::vector<std::vector<std::vector<Double_t> > > chip_ped_w_c1_slb;
     std::vector<std::vector<std::vector<Double_t> > > chip_ped_w_c2_slb;
 
@@ -302,41 +302,48 @@ void ReadPedestalsProtoCovariance(TString filename)
     for(int i=0; i<16; i++) {
       std::vector<std::vector<Double_t> > chip_ped_mean;
       std::vector<std::vector<Double_t> > chip_ped_w_i;
+      std::vector<std::vector<Double_t> > chip_ped_error;
       std::vector<std::vector<Double_t> > chip_ped_w_c1;
       std::vector<std::vector<Double_t> > chip_ped_w_c2;
 
       for(int j=0; j<64; j++) {
 	std::vector<Double_t> chn_ped_mean;
 	std::vector<Double_t> chn_ped_w_i;
+	std::vector<Double_t> chn_ped_error;
 	std::vector<Double_t> chn_ped_w_c1;
 	std::vector<Double_t> chn_ped_w_c2;
 
 	for(int isca=0; isca<15; isca++) {
 	  chn_ped_mean.push_back(-1);
 	  chn_ped_w_i.push_back(-1);
+	  chn_ped_error.push_back(-1);
 	  chn_ped_w_c1.push_back(-1);
 	  chn_ped_w_c2.push_back(-1);
 	}
 	chip_ped_mean.push_back(chn_ped_mean);
 	chip_ped_w_i.push_back(chn_ped_w_i);
+	chip_ped_error.push_back(chn_ped_error);
 	chip_ped_w_c1.push_back(chn_ped_w_c1);
 	chip_ped_w_c2.push_back(chn_ped_w_c2);
       }
       chip_ped_mean_slb.push_back(chip_ped_mean);
       chip_ped_w_i_slb.push_back(chip_ped_w_i);
+      chip_ped_error_slb.push_back(chip_ped_error);
       chip_ped_w_c1_slb.push_back(chip_ped_w_c1);
       chip_ped_w_c2_slb.push_back(chip_ped_w_c2);
     }
     ped_mean_slboard.push_back(chip_ped_mean_slb);
     ped_w_i_slboard.push_back(chip_ped_w_i_slb);
+    ped_error_slboard.push_back(chip_ped_error_slb);
     ped_w_c1_slboard.push_back(chip_ped_w_c1_slb);
     ped_w_c2_slboard.push_back(chip_ped_w_c2_slb);
   }
 
   Int_t tmp_layer=0, tmp_chip = 0,tmp_channel = 0;
-  Double_t tmp_ped[15], tmp_w_i[15], tmp_w_c1[15], tmp_w_c2[15];
+  Double_t tmp_ped[15], tmp_error[15], tmp_w_i[15], tmp_w_c1[15], tmp_w_c2[15];
   for(int isca=0; isca<15; isca++) {
     tmp_ped[isca]=0.;
+    tmp_error[isca]=0.;
     tmp_w_i[isca]=0.;
     tmp_w_c1[isca]=0.;
     tmp_w_c2[isca]=0.;
@@ -366,36 +373,36 @@ void ReadPedestalsProtoCovariance(TString filename)
   float tmperror=0;
   while(reading_file){
     reading_file >> tmp_layer >> tmp_chip >> tmp_channel >>
-      tmp_ped[0] >> tmp_w_i[0] >> tmp_w_c1[0] >>tmp_w_c2[0] >> tmperror >>
-      tmp_ped[1] >> tmp_w_i[1] >> tmp_w_c1[1] >>tmp_w_c2[1] >> tmperror >>
-      tmp_ped[2] >> tmp_w_i[2] >> tmp_w_c1[2] >>tmp_w_c2[2] >> tmperror >>
-      tmp_ped[3] >> tmp_w_i[3] >> tmp_w_c1[3] >>tmp_w_c2[3] >> tmperror >>
-      tmp_ped[4] >> tmp_w_i[4] >> tmp_w_c1[4] >>tmp_w_c2[4] >> tmperror >>
-      tmp_ped[5] >> tmp_w_i[5] >> tmp_w_c1[5] >>tmp_w_c2[5] >> tmperror >>
-      tmp_ped[6] >> tmp_w_i[6] >> tmp_w_c1[6] >>tmp_w_c2[6] >> tmperror >>
-      tmp_ped[7] >> tmp_w_i[7] >> tmp_w_c1[7] >>tmp_w_c2[7] >> tmperror >>
-      tmp_ped[8] >> tmp_w_i[8] >> tmp_w_c1[8] >>tmp_w_c2[8] >> tmperror >>
-      tmp_ped[9] >> tmp_w_i[9] >> tmp_w_c1[9] >>tmp_w_c2[9] >> tmperror >>
-      tmp_ped[10] >> tmp_w_i[10] >> tmp_w_c1[10] >>tmp_w_c2[10] >> tmperror >>
-      tmp_ped[11] >> tmp_w_i[11] >> tmp_w_c1[11] >>tmp_w_c2[11] >> tmperror >>
-      tmp_ped[12] >> tmp_w_i[12] >> tmp_w_c1[12] >>tmp_w_c2[12] >> tmperror >>
-      tmp_ped[13] >> tmp_w_i[13] >> tmp_w_c1[13] >>tmp_w_c2[13] >> tmperror >>
-      tmp_ped[14] >> tmp_w_i[14] >> tmp_w_c1[14] >>tmp_w_c2[14] >> tmperror;
+      tmp_ped[0] >> tmp_error[0] >> tmp_w_i[0] >> tmp_w_c1[0] >>tmp_w_c2[0] >>
+      tmp_ped[1] >> tmp_error[1] >> tmp_w_i[1] >> tmp_w_c1[1] >>tmp_w_c2[1] >>
+      tmp_ped[2] >> tmp_error[2] >> tmp_w_i[2] >> tmp_w_c1[2] >>tmp_w_c2[2] >>
+      tmp_ped[3] >> tmp_error[3] >> tmp_w_i[3] >> tmp_w_c1[3] >>tmp_w_c2[3] >>
+      tmp_ped[4] >> tmp_error[4] >> tmp_w_i[4] >> tmp_w_c1[4] >>tmp_w_c2[4] >>
+      tmp_ped[5] >> tmp_error[5] >> tmp_w_i[5] >> tmp_w_c1[5] >>tmp_w_c2[5] >>
+      tmp_ped[6] >> tmp_error[6] >> tmp_w_i[6] >> tmp_w_c1[6] >>tmp_w_c2[6] >>
+      tmp_ped[7] >> tmp_error[7] >> tmp_w_i[7] >> tmp_w_c1[7] >>tmp_w_c2[7] >>
+      tmp_ped[8] >> tmp_error[8] >> tmp_w_i[8] >> tmp_w_c1[8] >>tmp_w_c2[8] >>
+      tmp_ped[9] >> tmp_error[9] >> tmp_w_i[9] >> tmp_w_c1[9] >>tmp_w_c2[9] >>
+      tmp_ped[10] >> tmp_error[10] >> tmp_w_i[10] >> tmp_w_c1[10] >>tmp_w_c2[10] >>
+      tmp_ped[11] >> tmp_error[11] >> tmp_w_i[11] >> tmp_w_c1[11] >>tmp_w_c2[11] >>
+      tmp_ped[12] >> tmp_error[12] >> tmp_w_i[12] >> tmp_w_c1[12] >>tmp_w_c2[12] >>
+      tmp_ped[13] >> tmp_error[13] >> tmp_w_i[13] >> tmp_w_c1[13] >>tmp_w_c2[13] >>
+      tmp_ped[14] >> tmp_error[14] >> tmp_w_i[14] >> tmp_w_c1[14] >>tmp_w_c2[14];
 
     for(int isca=0; isca<15; isca++) {
       if(tmp_ped[isca]>0. ){//&& (tmp_w_i[isca]<ped_w_i.at(tmp_chip).at(tmp_channel).at(isca) || ped_w_i.at(tmp_chip).at(tmp_channel).at(isca)==0) ){
 	ped_mean_slboard.at(tmp_layer).at(tmp_chip).at(tmp_channel).at(isca)=tmp_ped[isca];
+	ped_error_slboard.at(tmp_layer).at(tmp_chip).at(tmp_channel).at(isca)=tmp_error[isca];
 	ped_w_i_slboard.at(tmp_layer).at(tmp_chip).at(tmp_channel).at(isca)=tmp_w_i[isca];
 	ped_w_c1_slboard.at(tmp_layer).at(tmp_chip).at(tmp_channel).at(isca)=tmp_w_c1[isca];
 	ped_w_c2_slboard.at(tmp_layer).at(tmp_chip).at(tmp_channel).at(isca)=tmp_w_c2[isca];
-	cout<<tmp_layer<<" "<<tmp_chip<<" "<<tmp_channel<<" "<<isca<<"  "<<ped_mean_slboard.at(tmp_layer).at(tmp_chip).at(tmp_channel).at(isca)<<endl;
+	//	cout<<tmp_layer<<" "<<tmp_chip<<" "<<tmp_channel<<" "<<isca<<"  "<<ped_error_slboard.at(tmp_layer).at(tmp_chip).at(tmp_channel).at(isca)<<endl;
       }
     }
 
   }
 
 }
-
 
 void ReadPedestalsProto(TString filename, bool invertedordering=false) 
 {

--- a/mip_calib/README
+++ b/mip_calib/README
@@ -1,10 +1,14 @@
 # A. Irles
 # irles NOT SMPAM @lal.in2p3.fr
 
-
-# 01/08/2019
-# Dummy list of MIP values created by createDummyMIPfiles.cc
-
+# 16/04/2022
+ Two set of MIP files are provided (for the low and high values of the dual gains)
+ First set corresponds to the settings with the gains optimzied for DESY energies (~GeV electrons) - 1.2pF for thick sensorrs (more than 320um) and 0.8pF for the 320um
+             --> https://llrelog.in2p3.fr/calice/2336
+ Second set corresponds to the settings optimzied for CERN energies (and ILC with ~100GeV electrons) - 6pF for all layers
+             -->  https://llrelog.in2p3.fr/calice/2324
+ Layer geometry explained here https://llrelog.in2p3.fr/calice/2325
+# Important NOTE --> the mip scans are from before the layer reshufling explained here https://llrelog.in2p3.fr/calice/2325 but the output files ahve been reshuffled to match the ordering described in the elog entry
 
 #24/01/2022
 Two different methods are used, for the pedestal calculation.
@@ -12,4 +16,8 @@ Two different methods are used, for the pedestal calculation.
 - the standard one (without special name) doing gaussian fits to the pedestal distributions (hit-bit=0)
 - method 2 based on https://arxiv.org/pdf/1401.7095.pdf
    ---> this one is taken as default one
+
+
+# 01/08/2019
+# Dummy list of MIP values created by createDummyMIPfiles.cc
 

--- a/pedestals/PlotsPedestal.C
+++ b/pedestals/PlotsPedestal.C
@@ -1,0 +1,226 @@
+#include "../include/utils.h"
+
+void Plots(TString name_="run_050575_injection_merged_ILCEnergyElectrons",TString st_gain="highgain"){
+
+  int nlayers=15;
+  int nchips=16;
+  int nsca=3;
+  
+  ReadPedestalsProtoCovariance("Pedestal_method2_"+name_+"_"+st_gain+".txt");
+  
+  TFile *_file1 = new TFile(TString::Format("plots/PedSummaryPlots_method2_%s_%s.root",name_.Data(),st_gain.Data()),"RECREATE");
+  _file1->cd();
+  
+  TFile *file0 = TFile::Open(TString::Format("PedSummary_method2_%s_%s.root",name_.Data(),st_gain.Data()));
+  TH2F * h2ped=(TH2F*)file0->Get("ped");
+  TH2F * h2ped_i=(TH2F*)file0->Get("ped_i");
+  TH2F * h2ped_c1=(TH2F*)file0->Get("ped_c1");
+  TH2F * h2ped_c2=(TH2F*)file0->Get("ped_c2");
+
+  _file1->cd();
+  h2ped->Write();
+  h2ped_i->Write();
+  h2ped_c1->Write();
+  h2ped_c2->Write();
+  //h2ped->Save(TString::Format("pedestal_map_%s.png",st_gain.Data()));
+  //  h2ped_i->Save(TString::Format("incoherent_map_%s.png",st_gain.Data()));
+
+  delete file0;
+
+  for(int layer=0; layer<nlayers; layer++) {
+    cout<<layer<<endl;
+    // TString map="../../../mapping/fev10_chip_channel_x_y_mapping.txt";
+    // if(layer==2 || layer==3)  map="../../../mapping/fev11_cob_chip_channel_x_y_mapping.txt";
+    // ReadMap(map,layer);
+    TGraphErrors *g_rms[16];
+    TGraphErrors *g_inoise[16];
+    TGraphErrors *g_totalnoise[16];
+    double minimum=1.01;
+    if(st_gain=="lowgain") minimum=0.1;
+	
+    for(int chip=0; chip<nchips; chip++) {
+
+      double x[15]={0}, ex[15]={0};
+      double yrms[15]={0}, eyrms[15]={0};
+      double yinoise[15]={0}, eyinoise[15]={0};
+      double ytotalnoise[15]={0}, eytotalnoise[15]={0};
+    
+      for(int isca=0; isca<nsca; isca++) {
+	x[isca]=isca;
+
+	double yrms_=0, eyrms_=0, nrms_=0;
+	double yinoise_=0, eyinoise_=0, ninoise_=0;
+	double ytotalnoise_=0, eytotalnoise_=0, ntotalnoise_=0;
+
+	//average
+	for(int j=0; j<64; j++) {
+	  if(ped_error_slboard.at(layer).at(chip).at(j).at(isca)>minimum) {
+	    yrms_+=ped_error_slboard.at(layer).at(chip).at(j).at(isca);
+	    nrms_++;
+	  }
+	  if(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca)>minimum) {
+	    yinoise_+=ped_w_i_slboard.at(layer).at(chip).at(j).at(isca);
+	    ninoise_++;
+	  }
+	  if(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca)>minimum) {
+	    ytotalnoise_+=sqrt(
+			       pow(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca),2)+
+			       pow(ped_w_c1_slboard.at(layer).at(chip).at(j).at(isca),2)+
+			       pow(ped_w_c2_slboard.at(layer).at(chip).at(j).at(isca),2));
+	    ntotalnoise_++;
+	  }
+	}//channel
+
+	if(nrms_>0) yrms_/=nrms_;
+	else yrms_=0;
+	if(ninoise_>0) yinoise_/=ninoise_;
+	else yinoise_=0;
+	if(ntotalnoise_>0) ytotalnoise_/=ntotalnoise_;
+	else ytotalnoise_=0;
+
+	//std dev
+	for(int j=0; j<64; j++) {
+	  if(ped_error_slboard.at(layer).at(chip).at(j).at(isca)>minimum) {
+	    eyrms_+=pow(ped_error_slboard.at(layer).at(chip).at(j).at(isca)-yrms_,2);
+	  }
+	  if(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca)>minimum) {
+	    eyinoise_+=pow(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca)-yinoise_,2);
+	  }
+	  if(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca)>minimum) {
+	    eytotalnoise_+=pow(sqrt(
+				    pow(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca),2)+
+				    pow(ped_w_c1_slboard.at(layer).at(chip).at(j).at(isca),2)+
+				    pow(ped_w_c2_slboard.at(layer).at(chip).at(j).at(isca),2))
+			       -
+			       ytotalnoise_,2);
+	  }
+	}//channel
+
+	if(nrms_>0) eyrms_=sqrt(eyrms_/nrms_);
+	else eyrms_=0;
+	if(ninoise_>0) eyinoise_=sqrt(eyinoise_/ninoise_);
+	else eyinoise_=0;
+	if(ntotalnoise_>0) eytotalnoise_=sqrt(eytotalnoise_/ntotalnoise_);
+	else eytotalnoise_=0;
+
+	yrms[isca]=yrms_; eyrms[isca]=eyrms_;
+  	yinoise[isca]=yinoise_; eyinoise[isca]=eyinoise_;
+	ytotalnoise[isca]=ytotalnoise_; eytotalnoise[isca]=eytotalnoise_;
+
+      }
+      g_rms[chip]=new TGraphErrors(nsca,x,yrms,ex,eyrms);
+      g_inoise[chip]=new TGraphErrors(nsca,x,yinoise,ex,eyinoise);
+      g_totalnoise[chip]=new TGraphErrors(nsca,x,ytotalnoise,ex,eytotalnoise);
+
+    }//ichip
+  
+
+    _file1->cd();
+ 					     
+    TCanvas* canvas0= new TCanvas(TString::Format("NoiseEstimations_%s_%s-layer%i",name_.Data(),st_gain.Data(),layer),TString::Format("NoiseEstimations_%s_%s-layer%i",name_.Data(),st_gain.Data(),layer),1200,1200);   
+    canvas0->Divide(2,2);
+    canvas0->cd(1);
+    TLegend * leg = new TLegend(0.2,0.2,0.8,0.8);
+    for(int chip=0; chip<16; chip++) {
+      if(chip!=9) {
+	g_rms[chip]->SetLineColor(chip+1);
+	g_rms[chip]->SetMarkerColor(chip+1);
+      } else {
+	g_rms[chip]->SetLineColor(1);
+	g_rms[chip]->SetMarkerColor(1);
+      }
+      g_rms[chip]->SetMarkerStyle(20+chip);
+      g_rms[chip]->SetMarkerSize(1.);
+
+      
+      if ( chip % 2 == 0) g_rms[chip]->SetLineStyle(2);
+      else g_rms[chip]->SetLineStyle(1);
+      if ( chip % 2 == 0) g_rms[chip]->SetLineWidth(2);
+      else g_rms[chip]->SetLineWidth(4);
+      if(chip==0) {
+	g_rms[chip]->GetYaxis()->SetRangeUser(minimum,5);
+	g_rms[chip]->GetYaxis()->SetTitle("ADC");
+	g_rms[chip]->GetXaxis()->SetTitle("SCA");
+	g_rms[chip]->SetTitle("Pedestal RMS");
+	g_rms[chip]->Draw("alp");
+      }
+      else g_rms[chip]->Draw("lp");
+      // g_rms[chip]->Write();
+      leg->AddEntry(g_rms[chip],TString::Format("ASIC:%i",chip),"lpe");
+    }
+
+    canvas0->cd(2);
+    for(int chip=0; chip<16; chip++) {
+      if(chip!=9) {
+	g_inoise[chip]->SetLineColor(chip+1);
+	g_inoise[chip]->SetMarkerColor(chip+1);
+      } else {
+	g_inoise[chip]->SetLineColor(1);
+	g_inoise[chip]->SetMarkerColor(1);
+      }
+      g_inoise[chip]->SetMarkerStyle(20+chip);
+      g_inoise[chip]->SetMarkerSize(1.);
+
+      
+      if ( chip % 2 == 0) g_inoise[chip]->SetLineStyle(2);
+      else g_inoise[chip]->SetLineStyle(1);
+      if ( chip % 2 == 0) g_inoise[chip]->SetLineWidth(2);
+      else g_inoise[chip]->SetLineWidth(4);
+      if(chip==0) {
+	g_inoise[chip]->GetYaxis()->SetRangeUser(minimum,5);
+	g_inoise[chip]->GetYaxis()->SetTitle("ADC");
+	g_inoise[chip]->GetXaxis()->SetTitle("SCA");
+	g_inoise[chip]->SetTitle("Pedestal Incoherent Noise");
+	g_inoise[chip]->Draw("alp");
+      }
+      else g_inoise[chip]->Draw("lp");
+      //  g_inoise[chip]->Write();
+    }
+
+    canvas0->cd(3);
+    for(int chip=0; chip<16; chip++) {
+      if(chip!=9) {
+	g_totalnoise[chip]->SetLineColor(chip+1);
+	g_totalnoise[chip]->SetMarkerColor(chip+1);
+      } else {
+	g_totalnoise[chip]->SetLineColor(1);
+	g_totalnoise[chip]->SetMarkerColor(1);
+      }
+      g_totalnoise[chip]->SetMarkerStyle(20+chip);
+      g_totalnoise[chip]->SetMarkerSize(1.);
+
+      
+      if ( chip % 2 == 0) g_totalnoise[chip]->SetLineStyle(2);
+      else g_totalnoise[chip]->SetLineStyle(1);
+      if ( chip % 2 == 0) g_totalnoise[chip]->SetLineWidth(2);
+      else g_totalnoise[chip]->SetLineWidth(4);
+      if(chip==0) {
+	g_totalnoise[chip]->GetYaxis()->SetRangeUser(minimum,5);
+	g_totalnoise[chip]->GetYaxis()->SetTitle("ADC");
+	g_totalnoise[chip]->GetXaxis()->SetTitle("SCA");
+	g_totalnoise[chip]->SetTitle("Pedestal incoherent+coherent noise");
+	g_totalnoise[chip]->Draw("alp");
+      }
+      else g_totalnoise[chip]->Draw("lp");
+      //      g_totalnoise[chip]->Write();
+    }
+    
+    canvas0->cd(4);
+    leg->Draw();
+    canvas0->Write();
+    canvas0->Print(TString::Format("plots/NoiseEstimations_layer%i_%s.png",layer,st_gain.Data()));
+    }
+}
+
+void PlotsPedestal(){
+
+  TString runs[2]={"run_050571_injection_merged_LowEnergyElectrons","run_050575_injection_merged_ILCEnergyElectrons"};
+  TString gain[2]={"highgain","lowgain"};
+  
+  for(int i=0; i<2; i++) {
+    for(int j=0; j<2; j++) {
+      Plots(runs[i],gain[j]);      
+    }
+  }
+
+}

--- a/pedestals/README
+++ b/pedestals/README
@@ -1,9 +1,14 @@
 # A. Irles
 # irles NOT SMPAM @lal.in2p3.fr
 
+# 11/04/2022
+# Two set of pedestal files are provided (for the low and high values of the dual gains)
+# First set corresponds to the settings with the gains optimzied for DESY energies (~GeV electrons) - 1.2pF for thick sensorrs (more than 320um) and 0.8pF for the 320um
+#             --> https://llrelog.in2p3.fr/calice/2336
+# Second set corresponds to the settings optimzied for CERN energies (and ILC with ~100GeV electrons) - 6pF for all layers
+#             -->  https://llrelog.in2p3.fr/calice/2324
+# Layer geometry explained here https://llrelog.in2p3.fr/calice/2325
 
-# 01/08/2019
-# Dummy list of pedestals for each slab made just checking a long shower run (42014) run
 
 #24/01/2022
 Two different methods and files.
@@ -11,3 +16,6 @@ Two different methods and files.
 - the standard one (without special name) doing gaussian fits to the pedestal distributions (hit-bit=0)
 - method 2 based on https://arxiv.org/pdf/1401.7095.pdf
    ---> this one is taken as default one
+
+# 01/08/2019
+# Dummy list of pedestals for each slab made just checking a long shower run (42014) run

--- a/pedestals/readwritepedestals.C
+++ b/pedestals/readwritepedestals.C
@@ -1,0 +1,97 @@
+#include "TFile.h"
+#include "TCanvas.h"
+#include "TPaveStats.h"
+#include "TH1.h"
+#include "TROOT.h"
+#include "TRint.h"
+#include "TStyle.h"
+#include "TLegend.h"
+#include "TString.h"
+#include "TH2.h"
+#include "TF1.h"
+#include "TMath.h"
+#include "TCanvas.h"
+#include "TSpectrum.h"
+#include <string>
+#include <sstream>
+#include <iostream>
+#include <fstream>
+#include "TLatex.h"
+#include "../include/utils.h"
+
+//#include "../../style/Style.C"
+//#include "../../style/Labels.C"
+
+using namespace std;
+
+void readwritepedestals(){
+
+  float high[15][16][64][15]={0.};
+  float low[15][16][64][15]={0.};
+
+  float low_av[15][16]={0.};
+  float high_av[15][16]={0.};
+  float n_av[15][16]={0.};
+
+  ReadPedestalsProtoCovariance("Pedestal_method2_Pedestal_run_050306_injection_merged_highgain.txt");
+
+  for(int layer=0;layer<15;layer++){
+    for(int i=0;i<16;i++){
+      n_av[layer][i]=0;
+      for(int j=0; j<64; j++) {
+	for(int k=0; k<15; k++) {
+	  high[layer][i][j][k]=ped_mean_slboard.at(layer).at(i).at(j).at(k);
+	  if(high[layer][i][j][k]>0) {
+	    n_av[layer][i]++;
+	    high_av[layer][i]+=high[layer][i][j][k];
+	  }
+	}
+      }
+      high_av[layer][i]/=n_av[layer][i];
+    }
+  }
+
+  ReadPedestalsProtoCovariance("Pedestal_method2_Pedestal_run_050306_injection_merged_lowgain.txt");
+
+  for(int layer=0;layer<15;layer++){
+    for(int i=0;i<16;i++){
+      n_av[layer][i]=0;
+      for(int j=0; j<64; j++) {
+	for(int k=0; k<15; k++) {
+	  low[layer][i][j][k]=ped_mean_slboard.at(layer).at(i).at(j).at(k);
+	  if(low[layer][i][j][k]>0) {
+	    n_av[layer][i]++;
+	    low_av[layer][i]+=low[layer][i][j][k];
+	  }
+	}
+      }
+      low_av[layer][i]/=n_av[layer][i];
+    }
+  }
+  
+
+
+  for(int layer=0; layer<15; layer++) {
+    ofstream fout_ped(TString::Format("Ped_Calib_Core0_SlabAdd%i_Asu0.txt",layer).Data(),ios::out);
+    fout_ped<<"Skiroc Ch SCA Gain PedestalValue [float in ADC count]"<<endl;
+    for(int i=0;i<16;i++){
+      for(int j=0; j<64; j++) {
+	fout_ped<<TString::Format("Skiroc %i Ch %i ",i,j)<<endl; 
+	fout_ped<<"Gain 0 "<<endl;
+	for(int k=0; k<15; k++) {
+	  if(low[layer][i][j][k]>0) fout_ped<<setprecision(6)<<low[layer][i][j][k]<<" ";
+	  else fout_ped<<setprecision(6)<<low_av[layer][i]<<" ";
+	}
+	fout_ped<<endl;
+	fout_ped<<"Gain 1 "<<endl;
+	for(int k=0; k<15; k++) {
+	  if(high[layer][i][j][k]>0) fout_ped<<setprecision(6)<<high[layer][i][j][k]<<" ";
+	  else fout_ped<<setprecision(6)<<high_av[layer][i]<<" ";
+	}
+	fout_ped<<endl;
+      }
+    }
+  }
+
+}
+


### PR DESCRIPTION
Please browse through the commits. There are few important changes that I believe that had to be done:

- Debugging of the conversion
- Renaming of the tree variables.. for historical reasons we were stilll using the "event" entry + a wrong name for the hitbits + unconsistent naming of the adc readings... I know that this creates some troubles in the event building and commissioning scripts but at some point we had to fix it. If you think that some of my choices are not useful or are confusing, please propose others. I'll be happy to implement them
- I include now an upgraded badbcid definition, to include the empty triggers in which the trigger is only in bcid +1. From what we discussed few days ago, I believe that the adc information is correct in the empty event but the hit bit triggers are correct (or seem so) in the bcid+1.
- There are also some changes in the noise study.


@yuichiok @kunathj 

**Edit** Before merging:

- [x] Merge #32 & rebase this PR on it
- [x] @kunathj add a final commit that changes the branch names in event building
  - Those commits are in #34
- [x] Resolve [this comment  concerning empty events](https://github.com/SiWECAL-TestBeam/SiWECAL-TB-analysis/pull/33#issuecomment-1095068221) -> [ee1086c](https://github.com/SiWECAL-TestBeam/SiWECAL-TB-analysis/pull/33/commits/ee1086c4442e70b779b26c816b22bece40c8f9ac)