### PR TITLE
Some bug correction

### DIFF
--- a/eventbuilding/build_events.py
+++ b/eventbuilding/build_events.py
@@ -392,11 +392,11 @@ class BuildEvents:
             if branch_name == "hit_energy":
                 mip = self.ecal_config.mip_map[event.hit_slab, event.hit_chip, event.hit_chan]
                 pedestal = self.ecal_config.pedestal_map[event.hit_slab, event.hit_chip, event.hit_chan, event.hit_sca]
-                arr = (event.hit_adc_high - pedestal) + mip
+                arr = (event.hit_adc_high - pedestal) / mip
             elif branch_name == "hit_energy_lg":
                 mip = self.ecal_config.mip_lg_map[event.hit_slab, event.hit_chip, event.hit_chan]
                 pedestal = self.ecal_config.pedestal_lg_map[event.hit_slab, event.hit_chip, event.hit_chan, event.hit_sca]
-                arr = (event.hit_adc_low - pedestal) + mip
+                arr = (event.hit_adc_low - pedestal) / mip
             elif branch_name == "hit_isCommissioned":
                 arr = self.ecal_config.is_commissioned_map[event.hit_slab, event.hit_chip, event.hit_chan, event.hit_sca]
             elif branch_name == "hit_isMasked":

--- a/eventbuilding/ecal_config.py
+++ b/eventbuilding/ecal_config.py
@@ -277,7 +277,9 @@ class EcalConfig:
         if np.any(has_bad_mip):
             mip_malfunctioning_chip = float(self._commissioning_config["mip_malfunctioning_chip"])
             channel_is_used_for_average = mip_map >= mip_cutoff
-            per_chip_average = channel_is_used_for_average.mean(axis=-1)
+            channel_is_used_for_average_with_mpv = np.where(channel_is_used_for_average, mip_map, 0)
+            np.seterr(invalid='ignore')
+            per_chip_average = np.true_divide(channel_is_used_for_average_with_mpv.sum(2),(channel_is_used_for_average_with_mpv!=0).sum(2))
             per_chip_average[per_chip_average == 0] = mip_malfunctioning_chip
             mip_average_on_chip = np.empty_like(mip_map)
             mip_average_on_chip[:] = np.expand_dims(


### PR DESCRIPTION
# Bug Fix
Some fix for bug was done that's affect energy calculation.

## Average MIP calculation

### Symptom
MIP values for the bad cells were assigned to be somewhere between 0 - 1.

### Issue
In the `ecal_config.py`, the script calculates the average MIP value for the chip by taking the mean in the array `channel_is_used_for_average`. Yet this is a boolean array.

### Solution
`channel_is_used_for_average` is replaced with `channel_is_used_for_average_with_mpv` which is an array with array with MIP values. Average now calculates the mean of all the good MIP values.

## Energy calculation
Minor bug fix for the energy calculation, in the function `_redo_fill_event` which is not really used.