### PR TITLE
Some bug correction (DUPLICATE)

### DIFF
--- a/SLBcommissioning/injection/LinearityGraphs.cc
+++ b/SLBcommissioning/injection/LinearityGraphs.cc
@@ -1,4 +1,4 @@
-//# Copyright 2020  Adrián Irles
+// # Copyright 2020  Adrián Irles
 
 #include "TROOT.h"
 #include "TFile.h"
@@ -14,166 +14,198 @@
 #include "TF1.h"
 #include "TMath.h"
 
-void LinearityGraphs(TString filename_in="/home/calice/TB2020/commissioning/SiWECAL-TB-analysis_TB2020/converter_SLB/convertedfiles/",
-		       TString run="calib_02272020_pa1.2fb_trig230_chn0.8.16.24_calib_small_Ascii", int nslboards=6){
-  
-  cout<<" Injection folder: "<<filename_in<<endl;
+void LinearityGraphs(TString filename_in = "/home/calice/TB2020/commissioning/SiWECAL-TB-analysis_TB2020/converter_SLB/convertedfiles/",
+                     TString run = "calib_02272020_pa1.2fb_trig230_chn0.8.16.24_calib_small_Ascii", int nslboards = 6)
+{
 
-  //slabs, chips, channels, sca, size --> yhigh, eyhigh, ylow, eylow
-  std::vector<std::vector<std::array<float,4>>> y;
- 
+  cout << " Injection folder: " << filename_in << endl;
+
+  // slabs, chips, channels, sca, size --> yhigh, eyhigh, ylow, eylow
+  std::vector<std::vector<std::array<float, 4>>> y;
+
   float x[100];
   float ex[100];
 
-  for(int l=0; l<100; l++) {
-    x[l]=0;
-    ex[l]=0;
+  for (int l = 0; l < 100; l++)
+  {
+    x[l] = 0;
+    ex[l] = 0;
   }
-  
-  for(int i=0; i<15; i++) {
-    for(int j=0; j<16; j++) {
-      for(int k=0; k<64; k++) {
-	for(int isca=0; isca<3; isca++) {
-	std:vector<std::array<float,4>> tempvec;
-	  for(int l=0; l<100; l++) {
-	    std::array<float,4> temp;
-	    temp[0]=0;
-	    temp[1]=0;
-	    temp[2]=0;
-	    temp[3]=0;
-	    tempvec.push_back(temp);
-	  }
-	  y.push_back(tempvec);
-	}
+
+  for (int i = 0; i < 15; i++)
+  {
+    for (int j = 0; j < 16; j++)
+    {
+      for (int k = 0; k < 64; k++)
+      {
+        for (int isca = 0; isca < 3; isca++)
+        {
+        std:
+          vector<std::array<float, 4>> tempvec;
+          for (int l = 0; l < 100; l++)
+          {
+            std::array<float, 4> temp;
+            temp[0] = 0;
+            temp[1] = 0;
+            temp[2] = 0;
+            temp[3] = 0;
+            tempvec.push_back(temp);
+          }
+          y.push_back(tempvec);
+        }
       }
     }
   }
 
-   int board_id[15];
- 
-  for(int i=0; i<15; i++) {
-    board_id[i]=-1;
-  }
-  
-  int count=0;
-  for(int i=0; i<15; i++) {
-    float pt=0.0;
-    if(i==0) pt=0.0;
-    if(i==1) pt=0.1;
-    if(i==2) pt=0.2;
-    if(i==3) pt=0.3;
-    if(i==4) pt=0.4;
-    if(i==5) pt=0.5;
-    if(i==6) pt=0.65;
-    if(i==7) pt=0.7;
-    if(i==8) pt=0.8;
-    if(i==9) pt=0.9;
-    if(i==10) pt=1.0;
-    if(i==11) pt=1.15;
-    if(i==12) pt=1.3;
-    if(i==13) pt=1.5;
-    if(i==14) pt=1.7;
-    
-    TString filename=filename_in+TString::Format("%s/injection_small_%.1fV.root",run.Data(),pt);
-    if(i==6 || i==11) filename=filename_in+TString::Format("%s/injection_small_%.2fV.root",run.Data(),pt);
+  int board_id[15];
 
-    cout<<" i: "<<i<<endl;
-    cout<<" Injection file: "<<filename_in<<endl;
+  for (int i = 0; i < 15; i++)
+  {
+    board_id[i] = -1;
+  }
+
+  int count = 0;
+  for (int i = 0; i < 15; i++)
+  {
+    float pt = 0.0;
+    if (i == 0)
+      pt = 0.0;
+    if (i == 1)
+      pt = 0.1;
+    if (i == 2)
+      pt = 0.2;
+    if (i == 3)
+      pt = 0.3;
+    if (i == 4)
+      pt = 0.4;
+    if (i == 5)
+      pt = 0.5;
+    if (i == 6)
+      pt = 0.65;
+    if (i == 7)
+      pt = 0.7;
+    if (i == 8)
+      pt = 0.8;
+    if (i == 9)
+      pt = 0.9;
+    if (i == 10)
+      pt = 1.0;
+    if (i == 11)
+      pt = 1.15;
+    if (i == 12)
+      pt = 1.3;
+    if (i == 13)
+      pt = 1.5;
+    if (i == 14)
+      pt = 1.7;
+
+    TString filename = filename_in + TString::Format("%s/injection_small_%.1fV.root", run.Data(), pt);
+    if (i == 6 || i == 11)
+      filename = filename_in + TString::Format("%s/injection_small_%.2fV.root", run.Data(), pt);
+
+    cout << " i: " << i << endl;
+    cout << " Injection file: " << filename_in << endl;
 
     DecodedSLBAnalysis ss(filename);
-    std::vector<std::array<float,9>> injecvalues=ss.InjectionAnalysis(-1);
+    std::vector<std::array<float, 9>> injecvalues = ss.InjectionAnalysis(-1);
 
-    x[count]=(3.3-pt-1.408);//2*(1-(pt-0.65));//(3.3-pt)/2.15;
-    
-    for(int j=0; j<injecvalues.size(); j++) {
-      if(board_id[int(injecvalues.at(j)[0])]==-1) board_id[int(injecvalues.at(j)[0])]=int(injecvalues.at(j)[1]);
+    x[count] = (3.3 - pt - 1.408); // 2*(1-(pt-0.65));//(3.3-pt)/2.15;
 
-      y.at(j).at(i)[0]=injecvalues.at(j)[5]; //yhigh
-      y.at(j).at(i)[1]=injecvalues.at(j)[6]; //eyhigh
-      
-      y.at(j).at(i)[2]=injecvalues.at(j)[7]; //ylow
-      y.at(j).at(i)[3]=injecvalues.at(j)[8]; //eylow
+    for (int j = 0; j < injecvalues.size(); j++)
+    {
+      if (board_id[int(injecvalues.at(j)[0])] == -1)
+        board_id[int(injecvalues.at(j)[0])] = int(injecvalues.at(j)[1]);
+
+      y.at(j).at(i)[0] = injecvalues.at(j)[5]; // yhigh
+      y.at(j).at(i)[1] = injecvalues.at(j)[6]; // eyhigh
+
+      y.at(j).at(i)[2] = injecvalues.at(j)[7]; // ylow
+      y.at(j).at(i)[3] = injecvalues.at(j)[8]; // eylow
     }
     count++;
-    
   }
 
+  TGraphErrors *injection_high_sca0[15][16][64];
+  TGraphErrors *injection_high_sca1[15][16][64];
+  TGraphErrors *injection_high_sca2[15][16][64];
 
-  
-  TGraphErrors* injection_high_sca0[15][16][64];
-  TGraphErrors* injection_high_sca1[15][16][64];
-  TGraphErrors* injection_high_sca2[15][16][64];
+  TGraphErrors *injection_low_sca0[6][16][64];
+  TGraphErrors *injection_low_sca1[6][16][64];
+  TGraphErrors *injection_low_sca2[6][16][64];
 
-  TGraphErrors* injection_low_sca0[6][16][64];
-  TGraphErrors* injection_low_sca1[6][16][64];
-  TGraphErrors* injection_low_sca2[6][16][64];
+  int counter = 0;
+  for (int i = 0; i < nslboards; i++)
+  {
+    for (int j = 0; j < 16; j++)
+    {
+      for (int k = 0; k < 64; k++)
+      {
+        for (int isca = 0; isca < 3; isca++)
+        {
 
+          float y0[100], ey0[100];
+          float y1[100], ey1[100];
 
-  int counter=0;
-  for(int i=0; i<nslboards; i++) {
-    for(int j=0; j<16; j++) {
-      for(int k=0; k<64; k++) {
-	for(int isca=0; isca<3; isca++) {
+          for (int ivec = 0; ivec < count; ivec++)
+          {
+            y0[ivec] = y.at(counter).at(ivec)[0];
+            ey0[ivec] = y.at(counter).at(ivec)[1];
+            y1[ivec] = y.at(counter).at(ivec)[2];
+            ey1[ivec] = y.at(counter).at(ivec)[3];
+          }
 
-	  float y0[100], ey0[100];
-	  float y1[100], ey1[100];
+          counter++;
 
-	  for(int ivec=0; ivec<count; ivec++) {
-	    y0[ivec]=y.at(counter).at(ivec)[0];
-	    ey0[ivec]=y.at(counter).at(ivec)[1];
-	    y1[ivec]=y.at(counter).at(ivec)[2];
-	    ey1[ivec]=y.at(counter).at(ivec)[3];
-	  }
-
-	  counter++;
-
-	  if(isca==0) {
-	    injection_high_sca0[i][j][k]= new TGraphErrors(count,x,y0,ex,ey0);
-	    injection_low_sca0[i][j][k]= new TGraphErrors(count,x,y1,ex,ey1);
-	  }
-	  if(isca==1) {
-	    injection_high_sca1[i][j][k]= new TGraphErrors(count,x,y0,ex,ey0);
-	    injection_low_sca1[i][j][k]= new TGraphErrors(count,x,y1,ex,ey1);
-	  }
-	  if(isca==2) {
-	    injection_high_sca2[i][j][k]= new TGraphErrors(count,x,y0,ex,ey0);
-	    injection_low_sca2[i][j][k]= new TGraphErrors(count,x,y1,ex,ey1);
-	  }	  
-
-	}
+          if (isca == 0)
+          {
+            injection_high_sca0[i][j][k] = new TGraphErrors(count, x, y0, ex, ey0);
+            injection_low_sca0[i][j][k] = new TGraphErrors(count, x, y1, ex, ey1);
+          }
+          if (isca == 1)
+          {
+            injection_high_sca1[i][j][k] = new TGraphErrors(count, x, y0, ex, ey0);
+            injection_low_sca1[i][j][k] = new TGraphErrors(count, x, y1, ex, ey1);
+          }
+          if (isca == 2)
+          {
+            injection_high_sca2[i][j][k] = new TGraphErrors(count, x, y0, ex, ey0);
+            injection_low_sca2[i][j][k] = new TGraphErrors(count, x, y1, ex, ey1);
+          }
+        }
       }
     }
   }
 
-  TFile *file_summary = new TFile("results/graphs_"+run+".root" , "RECREATE");
+  TFile *file_summary = new TFile("results/graphs_" + run + ".root", "RECREATE");
   file_summary->cd();
 
-  TH1F *h1 = new TH1F("layer_slboard_relation","layer_slboard_relation",nslboards,-0.5,nslboards-0.5);
-  for(int i=0; i<nslboards; i++) {
-    h1->Fill(i,board_id[i]);
+  TH1F *h1 = new TH1F("layer_slboard_relation", "layer_slboard_relation", nslboards, -0.5, nslboards - 0.5);
+  for (int i = 0; i < nslboards; i++)
+  {
+    h1->Fill(i, board_id[i]);
   }
   h1->Write();
-  
-  for(int i=0; i<nslboards; i++) {
-    for(int j=0; j<16; j++) {
-      for(int k=0; k<64; k++) {
-	injection_high_sca0[i][j][k]->SetName(TString::Format("high_gain_layer%i_slboard%i_chip%i_chn%i_sca0",i,board_id[i],j,k));
-	injection_high_sca1[i][j][k]->SetName(TString::Format("high_gain_layer%i_slboard%i_chip%i_chn%i_sca1",i,board_id[i],j,k));
-	injection_high_sca2[i][j][k]->SetName(TString::Format("high_gain_layer%i_slboard%i_chip%i_chn%i_sca2",i,board_id[i],j,k));
-	injection_low_sca0[i][j][k]->SetName(TString::Format("low_gain_layer%i_slboard%i_chip%i_chn%i_sca0",i,board_id[i],j,k));
-	injection_low_sca1[i][j][k]->SetName(TString::Format("low_gain_layer%i_slboard%i_chip%i_chn%i_sca1",i,board_id[i],j,k));
-	injection_low_sca2[i][j][k]->SetName(TString::Format("low_gain_layer%i_slboard%i_chip%i_chn%i_sca2",i,board_id[i],j,k));
 
-	injection_high_sca0[i][j][k]->Write();
-	injection_high_sca1[i][j][k]->Write();
-	injection_high_sca2[i][j][k]->Write();
-	injection_low_sca0[i][j][k]->Write();
-	injection_low_sca1[i][j][k]->Write();
-	injection_low_sca2[i][j][k]->Write();
+  for (int i = 0; i < nslboards; i++)
+  {
+    for (int j = 0; j < 16; j++)
+    {
+      for (int k = 0; k < 64; k++)
+      {
+        injection_high_sca0[i][j][k]->SetName(TString::Format("high_gain_layer%i_slboard%i_chip%i_chn%i_sca0", i, board_id[i], j, k));
+        injection_high_sca1[i][j][k]->SetName(TString::Format("high_gain_layer%i_slboard%i_chip%i_chn%i_sca1", i, board_id[i], j, k));
+        injection_high_sca2[i][j][k]->SetName(TString::Format("high_gain_layer%i_slboard%i_chip%i_chn%i_sca2", i, board_id[i], j, k));
+        injection_low_sca0[i][j][k]->SetName(TString::Format("low_gain_layer%i_slboard%i_chip%i_chn%i_sca0", i, board_id[i], j, k));
+        injection_low_sca1[i][j][k]->SetName(TString::Format("low_gain_layer%i_slboard%i_chip%i_chn%i_sca1", i, board_id[i], j, k));
+        injection_low_sca2[i][j][k]->SetName(TString::Format("low_gain_layer%i_slboard%i_chip%i_chn%i_sca2", i, board_id[i], j, k));
+
+        injection_high_sca0[i][j][k]->Write();
+        injection_high_sca1[i][j][k]->Write();
+        injection_high_sca2[i][j][k]->Write();
+        injection_low_sca0[i][j][k]->Write();
+        injection_low_sca1[i][j][k]->Write();
+        injection_low_sca2[i][j][k]->Write();
       }
     }
   }
-				 
-  
 }
-

--- a/SLBcommissioning/scurves/fithistos.C
+++ b/SLBcommissioning/scurves/fithistos.C
@@ -13,459 +13,527 @@
 #include "TF1.h"
 // #include "../conf_struct.h"
 
-//#include "../../style/Style.C"
-//#include "../../style/Labels.C"
+// #include "../../style/Style.C"
+// #include "../../style/Labels.C"
 
 using namespace std;
-
 
 float FirstZero(TGraphErrors *gr)
 {
 
-
-  int imax = TMath::LocMax(gr->GetN(),gr->GetY()); 
-  Double_t xmax,ymax;
+  int imax = TMath::LocMax(gr->GetN(), gr->GetY());
+  Double_t xmax, ymax;
   gr->GetPoint(imax, xmax, ymax);
 
-  //if(imax==0) return 0;
+  // if(imax==0) return 0;
 
-  for(int i=imax; i<gr->GetN(); i++) {
-      gr->GetPoint(i, xmax, ymax);
-      if(ymax<0.05) return xmax;
+  for (int i = imax; i < gr->GetN(); i++)
+  {
+    gr->GetPoint(i, xmax, ymax);
+    if (ymax < 0.05)
+      return xmax;
   }
 
   return 0;
-  
 }
 
-TF1 *FitScurve(TGraphErrors *gr, float xmin_=170, float xmax_=250, float x0=200)
+TF1 *FitScurve(TGraphErrors *gr, float xmin_ = 170, float xmax_ = 250, float x0 = 200)
 {
-   
-  double par1=0, par2=0, par3=0;
 
-  int imax = TMath::LocMax(gr->GetN(),gr->GetY());
-  int n=gr->GetN();
-  double* x = gr->GetX();
-  double* y = gr->GetY();
+  double par1 = 0, par2 = 0, par3 = 0;
 
-  if(n==0 || y[imax]==0) return NULL;
+  int imax = TMath::LocMax(gr->GetN(), gr->GetY());
+  int n = gr->GetN();
+  double *x = gr->GetX();
+  double *y = gr->GetY();
 
-  double xmin = max(x[imax],x[n/3])-3;
-  double xmax = FirstZero(gr)+10;
+  if (n == 0 || y[imax] == 0)
+    return NULL;
+
+  double xmin = max(x[imax], x[n / 3]) - 3;
+  double xmax = FirstZero(gr) + 10;
 
   double ymax = y[imax];
 
   //  std::cout<<"  ----------- 1 "<<endl;
 
-  TF1 *fit1 = new TF1("fit1","[0]*TMath::Erfc((x-[1])/(sqrt(2)*[2]))",xmin,xmax);
+  TF1 *fit1 = new TF1("fit1", "[0]*TMath::Erfc((x-[1])/(sqrt(2)*[2]))", xmin, xmax);
 
-  fit1->SetParLimits(0,ymax*0.1,ymax*10);
-  fit1->SetParLimits(1,xmin_,xmax_);
+  fit1->SetParLimits(0, ymax * 0.1, ymax * 10);
+  fit1->SetParLimits(1, xmin_, xmax_);
 
-  fit1->SetParameter(0,ymax);
-  fit1->SetParameter(1,x0);
-  fit1->SetParameter(2,3); 
-  gr->Fit("fit1","QR");
+  fit1->SetParameter(0, ymax);
+  fit1->SetParameter(1, x0);
+  fit1->SetParameter(2, 3);
+  gr->Fit("fit1", "QR");
 
-  par1=fit1->GetParameter(0); 
-  par2=fit1->GetParameter(1); 
-  par3=fit1->GetParameter(2);
-
+  par1 = fit1->GetParameter(0);
+  par2 = fit1->GetParameter(1);
+  par3 = fit1->GetParameter(2);
 
   // std::cout<<par1<<" "<<par2<<" "<<par3<<endl;
 
   //  std::cout<<"  ----------- 2 "<<endl;
 
-  if(par2<185) par2=190;
+  if (par2 < 185)
+    par2 = 190;
   //  if(par3<1) par3=1.5;
-  xmin=max(par2-8*par3,x[n/3]);
-  xmax=par2+20*par3;
-  TF1 *fit2 = new TF1("fit2","[0]*TMath::Erfc((x-[1])/[2]+[3])",xmin,xmax);
+  xmin = max(par2 - 8 * par3, x[n / 3]);
+  xmax = par2 + 20 * par3;
+  TF1 *fit2 = new TF1("fit2", "[0]*TMath::Erfc((x-[1])/[2]+[3])", xmin, xmax);
 
-  fit2->SetParLimits(0,par1*0.3,par1+par1*0.5);
-  fit2->SetParLimits(1,xmin_,xmax_);
-  fit2->SetParLimits(2,1.5,10);
+  fit2->SetParLimits(0, par1 * 0.3, par1 + par1 * 0.5);
+  fit2->SetParLimits(1, xmin_, xmax_);
+  fit2->SetParLimits(2, 1.5, 10);
 
   /* fit2->SetParameter(0,0.5*ymax);
   fit2->SetParameter(1,200);
   fit2->SetParameter(2,10); */
-  fit2->SetParameter(0,par1);
-  fit2->SetParameter(1,par2);
-  fit2->SetParameter(2,par3);
-  gr->Fit("fit2","QR");
-    
+  fit2->SetParameter(0, par1);
+  fit2->SetParameter(1, par2);
+  fit2->SetParameter(2, par3);
+  gr->Fit("fit2", "QR");
+
   return fit2;
 }
 
-
-std::vector<double> MeanSigma(TGraph *scurve_threshold, TString type="SK2a",int islab=-1, int iasic=-1) {
+std::vector<double> MeanSigma(TGraph *scurve_threshold, TString type = "SK2a", int islab = -1, int iasic = -1)
+{
 
   std::vector<double> result;
 
-  if(islab==-1 || iasic==-1) {
-    cout<<"ERROR in MeanSigma.... what slboard, iasic is this?"<<endl;
+  if (islab == -1 || iasic == -1)
+  {
+    cout << "ERROR in MeanSigma.... what slboard, iasic is this?" << endl;
     return result;
   }
-  double mean=0;
-  double sigma=0;
-  int max=0;
-  int min=10000000;
-  double nch=0;
-  for(int ichn=0; ichn<64; ichn++) {
-    if(detector.slab[0][islab].asu[0].skiroc[iasic].mask[ichn]==1) continue;
-    Double_t x,y;
+  double mean = 0;
+  double sigma = 0;
+  int max = 0;
+  int min = 10000000;
+  double nch = 0;
+  for (int ichn = 0; ichn < 64; ichn++)
+  {
+    if (detector.slab[0][islab].asu[0].skiroc[iasic].mask[ichn] == 1)
+      continue;
+    Double_t x, y;
     scurve_threshold->GetPoint(ichn, x, y);
-    if(y<400 && y>100) {
-      mean +=  y;
+    if (y < 400 && y > 100)
+    {
+      mean += y;
       nch++;
     }
-    if(y>max && y<400) max=y;
-    if(y<min && y>100) min=y;
+    if (y > max && y < 400)
+      max = y;
+    if (y < min && y > 100)
+      min = y;
   }
-  mean/=nch;
-  for(int ichn=0; ichn<64; ichn++) {
-    if(detector.slab[0][islab].asu[0].skiroc[iasic].mask[ichn]==1) continue;
-    Double_t x,y;
+  mean /= nch;
+  for (int ichn = 0; ichn < 64; ichn++)
+  {
+    if (detector.slab[0][islab].asu[0].skiroc[iasic].mask[ichn] == 1)
+      continue;
+    Double_t x, y;
     scurve_threshold->GetPoint(ichn, x, y);
-    if(y<400 && y>100) sigma +=  (y-mean)*(y-mean);
+    if (y < 400 && y > 100)
+      sigma += (y - mean) * (y - mean);
   }
-  sigma = sqrt( sigma/float(nch-1));
+  sigma = sqrt(sigma / float(nch - 1));
 
+  cout << " max:" << max << " optimal:" << mean << " std:" << sigma << " max-min:" << max - min << " type:" << type;
 
-  cout<<" max:" <<max<<" optimal:"<<mean<<" std:"<<sigma<<" max-min:"<<max-min<<" type:"<<type;
-
-  if( (max-min)>15)  max=mean+15;//3*sigma;
-  if(type=="SK2") max=TMath::Max(mean,235.0);
-  if(type=="SK2a") max=TMath::Max(max,225);
+  if ((max - min) > 15)
+    max = mean + 15; // 3*sigma;
+  if (type == "SK2")
+    max = TMath::Max(mean, 235.0);
+  if (type == "SK2a")
+    max = TMath::Max(max, 225);
   result.push_back(max);
 
   int th[64];
-  for(int ichn=0; ichn<64; ichn++) {
-    th[ichn]=0;
-    Double_t x,y;
+  for (int ichn = 0; ichn < 64; ichn++)
+  {
+    th[ichn] = 0;
+    Double_t x, y;
     scurve_threshold->GetPoint(ichn, x, y);
-    if(y<max)th[ichn]=int(max-y);
-    if(th[ichn]>15) th[ichn]=15;
-    if(type=="SK2") th[ichn]=0;
-    if(detector.slab[0][islab].asu[0].skiroc[iasic].mask[ichn]==1) th[ichn]=0;
+    if (y < max)
+      th[ichn] = int(max - y);
+    if (th[ichn] > 15)
+      th[ichn] = 15;
+    if (type == "SK2")
+      th[ichn] = 0;
+    if (detector.slab[0][islab].asu[0].skiroc[iasic].mask[ichn] == 1)
+      th[ichn] = 0;
     result.push_back(th[ichn]);
-
   }
-
-
 
   return result;
-
 }
 
+void fithistos(TString filename, std::vector<int> slboards, int iteration = 0, bool draw = true, bool write = true)
+{
 
-void fithistos(TString filename, std::vector<int> slboards , int iteration=0, bool draw=true, bool write=true){
-
-  if(slboards.size()==0 || slboards.size()>15) {
-    cout<<"ERROR: Size of vector of ids of the slboards = "<<slboards.size()<<endl;
+  if (slboards.size() == 0 || slboards.size() > 15)
+  {
+    cout << "ERROR: Size of vector of ids of the slboards = " << slboards.size() << endl;
   }
 
-  filename=filename;
-  if(write==true) {
-    read_configuration_file(TString::Format("../"+filename+"/Run_Settings_it%i.txt",iteration),false);
-    cout<< " Read FILE ..... " << TString::Format("../"+filename+"/Run_Settings_it%i.txt",iteration) <<endl;
+  filename = filename;
+  if (write == true)
+  {
+    read_configuration_file(TString::Format("../" + filename + "/Run_Settings_it%i.txt", iteration), false);
+    cout << " Read FILE ..... " << TString::Format("../" + filename + "/Run_Settings_it%i.txt", iteration) << endl;
   }
   TGraphErrors *scurve[15][16][64];
   TF1 *scurvefit[15][16][64];
 
-  TFile *file_summary = new TFile("histos/scurves_"+filename+".root" , "READ");
+  TFile *file_summary = new TFile("histos/scurves_" + filename + ".root", "READ");
   file_summary->cd();
 
-  for(int i=0; i<slboards.size(); i++) {
-    for(int iasic=0; iasic<16; iasic++) {
-      for(int ichn=0; ichn<64; ichn++) {
+  for (int i = 0; i < slboards.size(); i++)
+  {
+    for (int iasic = 0; iasic < 16; iasic++)
+    {
+      for (int ichn = 0; ichn < 64; ichn++)
+      {
 
-       scurve[i][iasic][ichn]=(TGraphErrors*)file_summary->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i",slboards.at(i),iasic,ichn));
-       scurvefit[i][iasic][ichn]=FitScurve(scurve[i][iasic][ichn]);
-     }
-   }
- }
-
- std::cout << scurve[1][0][5]->GetErrorX(2) << std::endl;
-
-
- TGraph *scurve_mean[15][16];
- TGraph *scurve_width[15][16];
- TGraph *scurve_threshold[15][16];
- TGraph *scurve_offset[15][16];
-
-
- for(int i=0; i<slboards.size(); i++) {
-  for(int iasic=0; iasic<16; iasic++) {
-    double mean[64];
-    double width[64];
-    double threshold[64];
-    double offset[64];
-    double chn[64];
-
-    for(int ichn=0; ichn<64; ichn++) {
-     mean[ichn]=-1;
-     width[ichn]=-1;
-     threshold[ichn]=-1;
-     offset[ichn]=-1;
-
-     chn[ichn]=ichn;
-
-     if(scurvefit[i][iasic][ichn]!=NULL) {
-       mean[ichn]=scurvefit[i][iasic][ichn]->GetParameter(1);
-       width[ichn]=scurvefit[i][iasic][ichn]->GetParameter(2);
-       threshold[ichn]=scurvefit[i][iasic][ichn]->GetParameter(1)+5*scurvefit[i][iasic][ichn]->GetParameter(2);
-       offset[ichn]=scurvefit[i][iasic][ichn]->GetParameter(3);
-     }
-	  //if(ichn==37)
-	  //cout<<" Result  " <<i<<  " "<<iasic <<" "<<ichn<<" "<< mean[ichn] << " " <<width[ichn] <<" "<<threshold[ichn]<<" "<<offset[ichn]<<endl;
-   }
-   scurve_mean[i][iasic]= new TGraph(64,chn,mean);
-   scurve_width[i][iasic]= new TGraph(64,chn,width);
-   scurve_threshold[i][iasic]= new TGraph(64,chn,threshold);
-   scurve_offset[i][iasic]= new TGraph(64,chn,offset);
-
- }
-}
-if(write ==true) {
-  for(int i=0; i<slboards.size(); i++) {
-    TString type="SK2";
-    if(detector.slab[0][i].add==4 || detector.slab[0][i].add==5 || detector.slab[0][i].add==6 || detector.slab[0][i].add==7 ){type = "SK2a";}
-    //if(detector.slab[0][i].add==0 ){ type = "SK2a"; }
-
-   for(int iasic=0; iasic<16; iasic++) {
-     cout<<" Thresholds for layer:" <<i<<" skiroc:"<<iasic <<" "<<type<<" ";
-     std::vector<double> mean_sigma = MeanSigma(scurve_threshold[i][iasic],type,slboards.at(i),iasic);
-     cout<<endl;
-     double mean=mean_sigma.at(0);
-     double fine_tuning[64];
-	//std::cout<<" -------------------------------------- "<< endl;
-	////      std::cout<<"slab: "<<i<<" asic:"<<iasic<<"    TH:"<<mean<< endl;
-     detector.slab[0][i].asu[0].skiroc[iasic].threshold_dac=mean;
-     for(int ichn=0; ichn<64; ichn++) {
-       fine_tuning[ichn]=mean_sigma.at(1+ichn);
-	  //	if(type=="SK2a") fine_tuning[ichn]=15;//mean_sigma.at(1+ichn);
-	  //else fine_tuning[ichn]=0;//mean_sigma.at(1+ichn);
-	  //std::cout<<" chn:"<<ichn<<" TH : "<<fine_tuning[ichn]<<endl;
-       detector.slab[0][i].asu[0].skiroc[iasic].chn_threshold_adj[ichn]=fine_tuning[ichn];
-     }
-   }
- }
-
- write_configuration_file(TString::Format("../"+filename+"/Run_Settings_comm_it%i.txt",iteration+1));
-
-}
-
-if(draw==true) {
-  TCanvas *canvas_asic[15];
-  
-  // for(int i=0; i<15; i++) {
-  for(int i=0; i<slboards.size(); i++) {
-   canvas_asic[i]= new TCanvas(TString::Format("canvas_slbAdd%i",i),TString::Format("canvas_slbAdd%i",i),1600,1600);
-   canvas_asic[i]->Divide(4,4);
-
-   for(int iasic=0; iasic<16; iasic++) {
-     canvas_asic[i]->cd(iasic+1);
-	  //scurve_threshold[i][iasic]->Draw("alp");
-	  // scurve_offset[i][iasic]->Draw("alp");
-
-     for(int ichn=0; ichn<64; ichn++) {
-	    //	    canvas_asic[i][iasic]->cd(1+ichn);
-       scurve[i][iasic][ichn]->GetXaxis()->SetTitle("DAC");
-       scurve[i][iasic][ichn]->GetYaxis()->SetTitle("Nhits");
-       scurve[i][iasic][ichn]->SetTitle(TString::Format("chn %i",ichn));
-       if(i==0) scurve[i][iasic][ichn]->Draw("alp");
-       if(i>0) scurve[i][iasic][ichn]->Draw("lp");
-     }
-   }
- }
-
-}
-
-}
-
-
-
-void fithistos_injection(TString filename, std::vector<int> slboards , int iteration=0, bool draw=true, bool write=true){
-
-  if(slboards.size()==0 || slboards.size()>15) {
-    cout<<"ERROR: Size of vector of ids of the slboards = "<<slboards.size()<<endl;
-  }
-
-  filename=filename;
-  if(write==true) {
-    read_configuration_file(TString::Format("../"+filename+"/Run_Settings_it%i.txt",iteration),false);
-    cout<< " Read FILE ..... " << TString::Format("../"+filename+"/Run_Settings_it%i.txt",iteration) <<endl;
-  }
-
-  //----------------------
-  TGraphErrors *scurve_1[15][16][64]={NULL};
-  TF1 *scurvefit_1[15][16][64]={NULL};
-
-  TFile *file_1_diag1 = new TFile("histos/scurves_"+filename+"_PROTO15_ADC85_diag1.root" , "READ");
-  TFile *file_1_diag2 = new TFile("histos/scurves_"+filename+"_PROTO15_ADC85_diag2.root" , "READ");
-  TFile *file_1_diag3 = new TFile("histos/scurves_"+filename+"_PROTO15_ADC85_diag3.root" , "READ");
-  TFile *file_1_diag4 = new TFile("histos/scurves_"+filename+"_PROTO15_ADC85_diag4.root" , "READ");
-
-  cout<<"histos/scurves_"+filename+"_PROTO15_ADC85_diag1.root"<<endl;
-  cout<<"histos/scurves_"+filename+"_PROTO15_ADC85_diag2.root"<<endl;
-  for(int i=0; i<slboards.size(); i++) {
-    for(int iasic=0; iasic<16; iasic++) {
-      for(int ichn=0; ichn<64; ichn++) {
-	file_1_diag1->cd();
-	scurve_1[i][iasic][ichn]=(TGraphErrors*)file_1_diag1->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i",slboards.at(i),iasic,ichn));
-	
-	if(scurve_1[i][iasic][ichn]->Integral()<1) {
-	  file_1_diag2->cd();
-	  scurve_1[i][iasic][ichn]=(TGraphErrors*)file_1_diag2->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i",slboards.at(i),iasic,ichn));
-	}
-	if(scurve_1[i][iasic][ichn]->Integral()<1) {
-	  file_1_diag3->cd();
-	  scurve_1[i][iasic][ichn]=(TGraphErrors*)file_1_diag3->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i",slboards.at(i),iasic,ichn));
-	}
-	if(scurve_1[i][iasic][ichn]->Integral()<1) {
-	  file_1_diag4->cd();
-	  scurve_1[i][iasic][ichn]=(TGraphErrors*)file_1_diag4->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i",slboards.at(i),iasic,ichn));
-	}
-	if(scurve_1[i][iasic][ichn]->Integral()>2) scurvefit_1[i][iasic][ichn]=FitScurve(scurve_1[i][iasic][ichn],300,400,350);
+        scurve[i][iasic][ichn] = (TGraphErrors *)file_summary->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i", slboards.at(i), iasic, ichn));
+        scurvefit[i][iasic][ichn] = FitScurve(scurve[i][iasic][ichn]);
       }
     }
   }
-  
-  //----------------------
-  TGraphErrors *scurve_2[15][16][64]={NULL};
-  TF1 *scurvefit_2[15][16][64]={NULL};
 
-  TFile *file_2_diag1 = new TFile("histos/scurves_"+filename+"_PROTO15_ADC120_diag1.root" , "READ");
-  TFile *file_2_diag2 = new TFile("histos/scurves_"+filename+"_PROTO15_ADC120_diag2.root" , "READ");
-  TFile *file_2_diag3 = new TFile("histos/scurves_"+filename+"_PROTO15_ADC120_diag3.root" , "READ");
-  TFile *file_2_diag4 = new TFile("histos/scurves_"+filename+"_PROTO15_ADC120_diag4.root" , "READ");
+  std::cout << scurve[1][0][5]->GetErrorX(2) << std::endl;
 
-  for(int i=0; i<slboards.size(); i++) {
-    for(int iasic=0; iasic<16; iasic++) {
-      for(int ichn=0; ichn<64; ichn++) {
-	file_2_diag1->cd();
-	scurve_2[i][iasic][ichn]=(TGraphErrors*)file_2_diag1->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i",slboards.at(i),iasic,ichn));
-	
-	if(scurve_2[i][iasic][ichn]->Integral()<1) {
-	  file_2_diag2->cd();
-	  scurve_2[i][iasic][ichn]=(TGraphErrors*)file_2_diag2->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i",slboards.at(i),iasic,ichn));
-	}
-	if(scurve_2[i][iasic][ichn]->Integral()<1) {
-	  file_2_diag3->cd();
-	  scurve_2[i][iasic][ichn]=(TGraphErrors*)file_2_diag3->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i",slboards.at(i),iasic,ichn));
-	}
-	if(scurve_2[i][iasic][ichn]->Integral()<1) {
-	  file_2_diag4->cd();
-	  scurve_2[i][iasic][ichn]=(TGraphErrors*)file_2_diag4->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i",slboards.at(i),iasic,ichn));
-	}
-	if(scurve_2[i][iasic][ichn]->Integral()>2) scurvefit_2[i][iasic][ichn]=FitScurve(scurve_2[i][iasic][ichn],420,500,440);
+  TGraph *scurve_mean[15][16];
+  TGraph *scurve_width[15][16];
+  TGraph *scurve_threshold[15][16];
+  TGraph *scurve_offset[15][16];
+
+  for (int i = 0; i < slboards.size(); i++)
+  {
+    for (int iasic = 0; iasic < 16; iasic++)
+    {
+      double mean[64];
+      double width[64];
+      double threshold[64];
+      double offset[64];
+      double chn[64];
+
+      for (int ichn = 0; ichn < 64; ichn++)
+      {
+        mean[ichn] = -1;
+        width[ichn] = -1;
+        threshold[ichn] = -1;
+        offset[ichn] = -1;
+
+        chn[ichn] = ichn;
+
+        if (scurvefit[i][iasic][ichn] != NULL)
+        {
+          mean[ichn] = scurvefit[i][iasic][ichn]->GetParameter(1);
+          width[ichn] = scurvefit[i][iasic][ichn]->GetParameter(2);
+          threshold[ichn] = scurvefit[i][iasic][ichn]->GetParameter(1) + 5 * scurvefit[i][iasic][ichn]->GetParameter(2);
+          offset[ichn] = scurvefit[i][iasic][ichn]->GetParameter(3);
+        }
+        // if(ichn==37)
+        // cout<<" Result  " <<i<<  " "<<iasic <<" "<<ichn<<" "<< mean[ichn] << " " <<width[ichn] <<" "<<threshold[ichn]<<" "<<offset[ichn]<<endl;
+      }
+      scurve_mean[i][iasic] = new TGraph(64, chn, mean);
+      scurve_width[i][iasic] = new TGraph(64, chn, width);
+      scurve_threshold[i][iasic] = new TGraph(64, chn, threshold);
+      scurve_offset[i][iasic] = new TGraph(64, chn, offset);
+    }
+  }
+  if (write == true)
+  {
+    for (int i = 0; i < slboards.size(); i++)
+    {
+      TString type = "SK2";
+      if (detector.slab[0][i].add == 4 || detector.slab[0][i].add == 5 || detector.slab[0][i].add == 6 || detector.slab[0][i].add == 7)
+      {
+        type = "SK2a";
+      }
+      // if(detector.slab[0][i].add==0 ){ type = "SK2a"; }
+
+      for (int iasic = 0; iasic < 16; iasic++)
+      {
+        cout << " Thresholds for layer:" << i << " skiroc:" << iasic << " " << type << " ";
+        std::vector<double> mean_sigma = MeanSigma(scurve_threshold[i][iasic], type, slboards.at(i), iasic);
+        cout << endl;
+        double mean = mean_sigma.at(0);
+        double fine_tuning[64];
+        // std::cout<<" -------------------------------------- "<< endl;
+        ////      std::cout<<"slab: "<<i<<" asic:"<<iasic<<"    TH:"<<mean<< endl;
+        detector.slab[0][i].asu[0].skiroc[iasic].threshold_dac = mean;
+        for (int ichn = 0; ichn < 64; ichn++)
+        {
+          fine_tuning[ichn] = mean_sigma.at(1 + ichn);
+          //	if(type=="SK2a") fine_tuning[ichn]=15;//mean_sigma.at(1+ichn);
+          // else fine_tuning[ichn]=0;//mean_sigma.at(1+ichn);
+          // std::cout<<" chn:"<<ichn<<" TH : "<<fine_tuning[ichn]<<endl;
+          detector.slab[0][i].asu[0].skiroc[iasic].chn_threshold_adj[ichn] = fine_tuning[ichn];
+        }
+      }
+    }
+
+    write_configuration_file(TString::Format("../" + filename + "/Run_Settings_comm_it%i.txt", iteration + 1));
+  }
+
+  if (draw == true)
+  {
+    TCanvas *canvas_asic[15];
+
+    // for(int i=0; i<15; i++) {
+    for (int i = 0; i < slboards.size(); i++)
+    {
+      canvas_asic[i] = new TCanvas(TString::Format("canvas_slbAdd%i", i), TString::Format("canvas_slbAdd%i", i), 1600, 1600);
+      canvas_asic[i]->Divide(4, 4);
+
+      for (int iasic = 0; iasic < 16; iasic++)
+      {
+        canvas_asic[i]->cd(iasic + 1);
+        // scurve_threshold[i][iasic]->Draw("alp");
+        //  scurve_offset[i][iasic]->Draw("alp");
+
+        for (int ichn = 0; ichn < 64; ichn++)
+        {
+          //	    canvas_asic[i][iasic]->cd(1+ichn);
+          scurve[i][iasic][ichn]->GetXaxis()->SetTitle("DAC");
+          scurve[i][iasic][ichn]->GetYaxis()->SetTitle("Nhits");
+          scurve[i][iasic][ichn]->SetTitle(TString::Format("chn %i", ichn));
+          if (i == 0)
+            scurve[i][iasic][ichn]->Draw("alp");
+          if (i > 0)
+            scurve[i][iasic][ichn]->Draw("lp");
+        }
       }
     }
   }
-  
+}
 
+void fithistos_injection(TString filename, std::vector<int> slboards, int iteration = 0, bool draw = true, bool write = true)
+{
 
-  double mean_1[15][16]={0};
-  double n_1[15][16]={0};
-  double mean_2[15][16]={0};
-  double n_2[15][16]={0};
-  
-  for(int i=0; i<slboards.size(); i++) {
-    for(int iasic=0; iasic<16; iasic++) {   
-	for(int ichn=0; ichn<64; ichn++) {  
-	  if(scurvefit_1[i][iasic][ichn]!=NULL) {
-	    if(scurvefit_1[i][iasic][ichn]->GetParError(1)<20) {
-	      mean_1[i][iasic]+=scurvefit_1[i][iasic][ichn]->GetParameter(1);
-	      n_1[i][iasic]++;
-	    }
-	  }
-	  if(scurvefit_2[i][iasic][ichn]!=NULL) {
-	    if(scurvefit_2[i][iasic][ichn]->GetParError(1)<20) {
-	      mean_2[i][iasic]+=scurvefit_2[i][iasic][ichn]->GetParameter(1);
-	      n_2[i][iasic]++;
-	    }
-	  }
-	}
+  if (slboards.size() == 0 || slboards.size() > 15)
+  {
+    cout << "ERROR: Size of vector of ids of the slboards = " << slboards.size() << endl;
+  }
+
+  filename = filename;
+  if (write == true)
+  {
+    read_configuration_file(TString::Format("../" + filename + "/Run_Settings_it%i.txt", iteration), false);
+    cout << " Read FILE ..... " << TString::Format("../" + filename + "/Run_Settings_it%i.txt", iteration) << endl;
+  }
+
+  //----------------------
+  TGraphErrors *scurve_1[15][16][64] = {NULL};
+  TF1 *scurvefit_1[15][16][64] = {NULL};
+
+  TFile *file_1_diag1 = new TFile("histos/scurves_" + filename + "_PROTO15_ADC85_diag1.root", "READ");
+  TFile *file_1_diag2 = new TFile("histos/scurves_" + filename + "_PROTO15_ADC85_diag2.root", "READ");
+  TFile *file_1_diag3 = new TFile("histos/scurves_" + filename + "_PROTO15_ADC85_diag3.root", "READ");
+  TFile *file_1_diag4 = new TFile("histos/scurves_" + filename + "_PROTO15_ADC85_diag4.root", "READ");
+
+  cout << "histos/scurves_" + filename + "_PROTO15_ADC85_diag1.root" << endl;
+  cout << "histos/scurves_" + filename + "_PROTO15_ADC85_diag2.root" << endl;
+  for (int i = 0; i < slboards.size(); i++)
+  {
+    for (int iasic = 0; iasic < 16; iasic++)
+    {
+      for (int ichn = 0; ichn < 64; ichn++)
+      {
+        file_1_diag1->cd();
+        scurve_1[i][iasic][ichn] = (TGraphErrors *)file_1_diag1->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i", slboards.at(i), iasic, ichn));
+
+        if (scurve_1[i][iasic][ichn]->Integral() < 1)
+        {
+          file_1_diag2->cd();
+          scurve_1[i][iasic][ichn] = (TGraphErrors *)file_1_diag2->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i", slboards.at(i), iasic, ichn));
+        }
+        if (scurve_1[i][iasic][ichn]->Integral() < 1)
+        {
+          file_1_diag3->cd();
+          scurve_1[i][iasic][ichn] = (TGraphErrors *)file_1_diag3->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i", slboards.at(i), iasic, ichn));
+        }
+        if (scurve_1[i][iasic][ichn]->Integral() < 1)
+        {
+          file_1_diag4->cd();
+          scurve_1[i][iasic][ichn] = (TGraphErrors *)file_1_diag4->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i", slboards.at(i), iasic, ichn));
+        }
+        if (scurve_1[i][iasic][ichn]->Integral() > 2)
+          scurvefit_1[i][iasic][ichn] = FitScurve(scurve_1[i][iasic][ichn], 300, 400, 350);
+      }
     }
   }
 
-  for(int i=0; i<slboards.size(); i++) {
-    for(int iasic=0; iasic<16; iasic++) {
-      if(n_1[i][iasic]!=0) mean_1[i][iasic]/=n_1[i][iasic];
-      else mean_1[i][iasic]=0;
-      if(n_2[i][iasic]!=0) mean_2[i][iasic]/=n_2[i][iasic];
-      else mean_2[i][iasic]=0;
+  //----------------------
+  TGraphErrors *scurve_2[15][16][64] = {NULL};
+  TF1 *scurvefit_2[15][16][64] = {NULL};
+
+  TFile *file_2_diag1 = new TFile("histos/scurves_" + filename + "_PROTO15_ADC120_diag1.root", "READ");
+  TFile *file_2_diag2 = new TFile("histos/scurves_" + filename + "_PROTO15_ADC120_diag2.root", "READ");
+  TFile *file_2_diag3 = new TFile("histos/scurves_" + filename + "_PROTO15_ADC120_diag3.root", "READ");
+  TFile *file_2_diag4 = new TFile("histos/scurves_" + filename + "_PROTO15_ADC120_diag4.root", "READ");
+
+  for (int i = 0; i < slboards.size(); i++)
+  {
+    for (int iasic = 0; iasic < 16; iasic++)
+    {
+      for (int ichn = 0; ichn < 64; ichn++)
+      {
+        file_2_diag1->cd();
+        scurve_2[i][iasic][ichn] = (TGraphErrors *)file_2_diag1->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i", slboards.at(i), iasic, ichn));
+
+        if (scurve_2[i][iasic][ichn]->Integral() < 1)
+        {
+          file_2_diag2->cd();
+          scurve_2[i][iasic][ichn] = (TGraphErrors *)file_2_diag2->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i", slboards.at(i), iasic, ichn));
+        }
+        if (scurve_2[i][iasic][ichn]->Integral() < 1)
+        {
+          file_2_diag3->cd();
+          scurve_2[i][iasic][ichn] = (TGraphErrors *)file_2_diag3->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i", slboards.at(i), iasic, ichn));
+        }
+        if (scurve_2[i][iasic][ichn]->Integral() < 1)
+        {
+          file_2_diag4->cd();
+          scurve_2[i][iasic][ichn] = (TGraphErrors *)file_2_diag4->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i", slboards.at(i), iasic, ichn));
+        }
+        if (scurve_2[i][iasic][ichn]->Integral() > 2)
+          scurvefit_2[i][iasic][ichn] = FitScurve(scurve_2[i][iasic][ichn], 420, 500, 440);
+      }
+    }
+  }
+
+  double mean_1[15][16] = {0};
+  double n_1[15][16] = {0};
+  double mean_2[15][16] = {0};
+  double n_2[15][16] = {0};
+
+  for (int i = 0; i < slboards.size(); i++)
+  {
+    for (int iasic = 0; iasic < 16; iasic++)
+    {
+      for (int ichn = 0; ichn < 64; ichn++)
+      {
+        if (scurvefit_1[i][iasic][ichn] != NULL)
+        {
+          if (scurvefit_1[i][iasic][ichn]->GetParError(1) < 20)
+          {
+            mean_1[i][iasic] += scurvefit_1[i][iasic][ichn]->GetParameter(1);
+            n_1[i][iasic]++;
+          }
+        }
+        if (scurvefit_2[i][iasic][ichn] != NULL)
+        {
+          if (scurvefit_2[i][iasic][ichn]->GetParError(1) < 20)
+          {
+            mean_2[i][iasic] += scurvefit_2[i][iasic][ichn]->GetParameter(1);
+            n_2[i][iasic]++;
+          }
+        }
+      }
+    }
+  }
+
+  for (int i = 0; i < slboards.size(); i++)
+  {
+    for (int iasic = 0; iasic < 16; iasic++)
+    {
+      if (n_1[i][iasic] != 0)
+        mean_1[i][iasic] /= n_1[i][iasic];
+      else
+        mean_1[i][iasic] = 0;
+      if (n_2[i][iasic] != 0)
+        mean_2[i][iasic] /= n_2[i][iasic];
+      else
+        mean_2[i][iasic] = 0;
     }
   }
 
   // HARD CODED ADC-to-MIP dependence.. based on the cosmic run_050010
   // 320 um ->  1MIP = 58ADC
   // 500 um ->  1MIP = 70ADC
-  cout<<" FIRST CASE"<<endl;
-  double MIP[15][16]={0};
-  double injected1=85;
-  double injected2=120;
+  cout << " FIRST CASE" << endl;
+  double MIP[15][16] = {0};
+  double injected1 = 85;
+  double injected2 = 120;
 
-  for(int i=0; i<slboards.size(); i++) {
-    for(int iasic=0; iasic<16; iasic++) {
-      MIP[i][iasic]=58;
-      if(i>3 && i<8) MIP[i][iasic]=70;
-      if(i==2 && iasic<4) MIP[i][iasic]=70;
+  for (int i = 0; i < slboards.size(); i++)
+  {
+    for (int iasic = 0; iasic < 16; iasic++)
+    {
+      MIP[i][iasic] = 58;
+      if (i > 3 && i < 8)
+        MIP[i][iasic] = 70;
+      if (i == 2 && iasic < 4)
+        MIP[i][iasic] = 70;
     }
   }
 
-  float dac[15]={0};
-  float nfits[15]={0};
-  for(int i=0; i<slboards.size(); i++) {
-    for(int iasic=0; iasic<16; iasic++) {
+  float dac[15] = {0};
+  float nfits[15] = {0};
+  for (int i = 0; i < slboards.size(); i++)
+  {
+    for (int iasic = 0; iasic < 16; iasic++)
+    {
 
-      double x1=injected1/MIP[i][iasic];
-      double x2=injected2/MIP[i][iasic];
-      float optimal = 0; 
-      if(n_1[i][iasic]>1 && n_2[i][iasic]>1) {
-	dac[i] += mean_1[i][iasic] - ( (x1-0.5)/ (x2-x1) ) * ( mean_2[i][iasic] - mean_1[i][iasic]);
-	nfits[i]++;
+      double x1 = injected1 / MIP[i][iasic];
+      double x2 = injected2 / MIP[i][iasic];
+      float optimal = 0;
+      if (n_1[i][iasic] > 1 && n_2[i][iasic] > 1)
+      {
+        dac[i] += mean_1[i][iasic] - ((x1 - 0.5) / (x2 - x1)) * (mean_2[i][iasic] - mean_1[i][iasic]);
+        nfits[i]++;
       }
     }
-    dac[i]/=nfits[i];
+    dac[i] /= nfits[i];
   }
 
-  float dac_chip[15][16]={0};
-  for(int i=0; i<slboards.size(); i++) {
-    for(int iasic=0; iasic<16; iasic++) {
-      double x1=injected1/MIP[i][iasic];
-      double x2=injected2/MIP[i][iasic];
-      
-      if(n_1[i][iasic]>1 && n_2[i][iasic]>1) {
-	dac_chip[i][iasic] = mean_1[i][iasic] - ( (x1-0.5)/ (x2-x1) ) * ( mean_2[i][iasic] - mean_1[i][iasic]);
-      } else dac_chip[i][iasic]=dac[i];
+  float dac_chip[15][16] = {0};
+  for (int i = 0; i < slboards.size(); i++)
+  {
+    for (int iasic = 0; iasic < 16; iasic++)
+    {
+      double x1 = injected1 / MIP[i][iasic];
+      double x2 = injected2 / MIP[i][iasic];
+
+      if (n_1[i][iasic] > 1 && n_2[i][iasic] > 1)
+      {
+        dac_chip[i][iasic] = mean_1[i][iasic] - ((x1 - 0.5) / (x2 - x1)) * (mean_2[i][iasic] - mean_1[i][iasic]);
+      }
+      else
+        dac_chip[i][iasic] = dac[i];
     }
   }
 
-  if(write ==true) {
-    for(int i=0; i<slboards.size(); i++) {	       
-      for(int iasic=0; iasic<16; iasic++) {
+  if (write == true)
+  {
+    for (int i = 0; i < slboards.size(); i++)
+    {
+      for (int iasic = 0; iasic < 16; iasic++)
+      {
 
-	cout<<i<<" "<<iasic<<" "<<detector.slab[0][i].asu[0].skiroc[iasic].threshold_dac<<endl;
-	if(detector.slab[0][i].add==4 || detector.slab[0][i].add==5 || detector.slab[0][i].add==6 || detector.slab[0][i].add==7 ) {
-	  detector.slab[0][i].asu[0].skiroc[iasic].threshold_dac=dac_chip[i][iasic]+15;
-	  for(int ichn=0; ichn<64; ichn++) detector.slab[0][i].asu[0].skiroc[iasic].chn_threshold_adj[ichn]=15;
-	} else {
-	  detector.slab[0][i].asu[0].skiroc[iasic].threshold_dac=dac_chip[i][iasic];
-	  for(int ichn=0; ichn<64; ichn++) detector.slab[0][i].asu[0].skiroc[iasic].chn_threshold_adj[ichn]=0;
-	}
-	cout<<i<<" "<<iasic<<" "<<detector.slab[0][i].asu[0].skiroc[iasic].threshold_dac<<endl;
+        cout << i << " " << iasic << " " << detector.slab[0][i].asu[0].skiroc[iasic].threshold_dac << endl;
+        if (detector.slab[0][i].add == 4 || detector.slab[0][i].add == 5 || detector.slab[0][i].add == 6 || detector.slab[0][i].add == 7)
+        {
+          detector.slab[0][i].asu[0].skiroc[iasic].threshold_dac = dac_chip[i][iasic] + 15;
+          for (int ichn = 0; ichn < 64; ichn++)
+            detector.slab[0][i].asu[0].skiroc[iasic].chn_threshold_adj[ichn] = 15;
+        }
+        else
+        {
+          detector.slab[0][i].asu[0].skiroc[iasic].threshold_dac = dac_chip[i][iasic];
+          for (int ichn = 0; ichn < 64; ichn++)
+            detector.slab[0][i].asu[0].skiroc[iasic].chn_threshold_adj[ichn] = 0;
+        }
+        cout << i << " " << iasic << " " << detector.slab[0][i].asu[0].skiroc[iasic].threshold_dac << endl;
       }
     }
-      
-    write_configuration_file(TString::Format("../"+filename+"/Run_Settings_comm_it%i.txt",iteration+1));
-    cout<<TString::Format("../"+filename+"/Run_Settings_comm_it%i.txt",iteration+1)<<endl;
+
+    write_configuration_file(TString::Format("../" + filename + "/Run_Settings_comm_it%i.txt", iteration + 1));
+    cout << TString::Format("../" + filename + "/Run_Settings_comm_it%i.txt", iteration + 1) << endl;
   }
-
-
-
 }
-
-
-

--- a/SLBcommissioning/test_read_masked_channels.C
+++ b/SLBcommissioning/test_read_masked_channels.C
@@ -73,7 +73,7 @@ void test_read_masked_channels(TString filename = "15102021/Run_Settings_DataTak
     }
     cout << "TOTAL Masked cells:" << 100. * totalmasked[islab] / 1024. << "%" << endl;
 
-    TCanvas *canvas = new TCanvas(TString::Format("canvas_%i", islab), TString::Format("canvas_%i", islab), 800, 1600);
+    TCanvas *canvas = new TCanvas(TString::Format("canvas_%i", islab), TString::Format("canvas_%i", islab), 500, 1000);
     gStyle->SetOptStat(0);
     gStyle->SetPalette(kInvertedDarkBodyRadiator); // Cherry);
     // TColor::InvertPalette();
@@ -95,6 +95,29 @@ void test_read_masked_channels(TString filename = "15102021/Run_Settings_DataTak
     canvas->Print(TString::Format("plots/masked_channels_SlabAdd%i.pdf", islab));
 
   }
+
+  TCanvas *canvas_chn_chip = new TCanvas("canvas_chn_chip", "canvas_chn_chip", 800, 800);
+  gStyle->SetOptStat(0);
+  gStyle->SetPalette(kInvertedDarkBodyRadiator); // Cherry);
+  mask_chip_chn[0]->SetTitle("Layer 0 Mask cells Chip vs. Channel");
+  mask_chip_chn[0]->GetXaxis()->SetTitle("CHIP");
+  mask_chip_chn[0]->GetYaxis()->SetTitle("CHANNEL");
+  gPad->SetLeftMargin(0.12);
+  gPad->SetRightMargin(0.09);
+  mask_chip_chn[0]->Draw("col");
+  canvas_chn_chip->Print("plots/mask_ChipChn_slab0.pdf");
+
+  TCanvas *canvas_x_y = new TCanvas("canvas_x_y", "canvas_x_y", 800, 800);
+  gStyle->SetOptStat(0);
+  gStyle->SetPalette(kInvertedDarkBodyRadiator); // Cherry);
+  mask_x_y[0]->SetTitle("Layer 0 Mask cells XY positions");
+  mask_x_y[0]->GetXaxis()->SetTitle("x");
+  mask_x_y[0]->GetYaxis()->SetTitle("y");
+  gPad->SetLeftMargin(0.12);
+  gPad->SetRightMargin(0.09);
+  mask_x_y[0]->Draw("col");
+  canvas_x_y->Print("plots/mask_xy_slab0.pdf");
+
 
   cout << "################################################################" << endl;
   cout << "################################################################" << endl;

--- a/SLBcommissioning/test_read_masked_channels.C
+++ b/SLBcommissioning/test_read_masked_channels.C
@@ -4,7 +4,7 @@
 
 void test_read_masked_channels(TString filename = "15102021/Run_Settings_DataTaking_TB2021_15102021", bool debug = true)
 {
-  read_configuration_file(filename + ".txt", true);
+  read_configuration_file(filename, true);
 
   TH2F *mask_chip_chn[15];
   TH2F *mask_x_y[15];
@@ -80,18 +80,20 @@ void test_read_masked_channels(TString filename = "15102021/Run_Settings_DataTak
     canvas->Divide(1, 2);
     canvas->cd(1);
     // mask_chip_chn[islab]->SetTitle(TString::Format("SLABd%i",mapping_slab[islab]));
-    mask_chip_chn[islab]->SetTitle(TString::Format("SlabAdd%i", islab));
+    mask_chip_chn[islab]->SetTitle(TString::Format("Layer %i Mask cells Chip vs. Channel", islab));
     mask_chip_chn[islab]->GetXaxis()->SetTitle("CHIP");
     mask_chip_chn[islab]->GetYaxis()->SetTitle("CHANNEL");
     mask_chip_chn[islab]->Draw("col");
     canvas->cd(2);
-    mask_x_y[islab]->SetTitle(TString::Format("SLABd%i",mapping_slab[islab]));
+    mask_x_y[islab]->SetTitle(TString::Format("Layer %i Mask cells XY positions",islab));
+    // mask_x_y[islab]->SetTitle(TString::Format("SLABd%i",mapping_slab[islab]));
     // mask_x_y[islab]->SetTitle(TString::Format("SlabAdd%i", islab));
     mask_x_y[islab]->GetXaxis()->SetTitle("x");
     mask_x_y[islab]->GetYaxis()->SetTitle("y");
     mask_x_y[islab]->Draw("col");
     // canvas->Print(TString::Format("masked_channels_SLAB%i.png",mapping_slab[islab]));
-    canvas->Print(TString::Format("plots/masked_channels_SlabAdd%i.png", islab));
+    canvas->Print(TString::Format("plots/masked_channels_SlabAdd%i.pdf", islab));
+
   }
 
   cout << "################################################################" << endl;

--- a/SLBcommissioning/test_read_masked_channels_TB.C
+++ b/SLBcommissioning/test_read_masked_channels_TB.C
@@ -1,62 +1,67 @@
-//# Copyright 2020  Adrián Irles (IJCLab, CNRS/IN2P3)
+// # Copyright 2020  Adrián Irles (IJCLab, CNRS/IN2P3)
 
 #include "conf_struct.h"
 
-void test_read_masked_channels_TB(TString filename="/mnt/HardDrive/beamData/ascii/1.4GeV_W_run_050163/Run_Settings.txt", TString filename_out="test") {
+void test_read_masked_channels_TB(TString filename = "/mnt/HardDrive/beamData/ascii/1.4GeV_W_run_050163/Run_Settings.txt", TString filename_out = "test")
+{
 
-  read_configuration_file(filename,true);
+  read_configuration_file(filename, true);
 
-  TH2F* mask_chip_chn = new TH2F("mask_chip_chn","mask_chip_chn",16,-0.5,15.5,64,-0.5,63.5);
-  TH2F* mask_x_y = new TH2F("mask_x_y","mask_x_y",32,-90,90,32,-90,90);
+  TH2F *mask_chip_chn = new TH2F("mask_chip_chn", "mask_chip_chn", 16, -0.5, 15.5, 64, -0.5, 63.5);
+  TH2F *mask_x_y = new TH2F("mask_x_y", "mask_x_y", 32, -90, 90, 32, -90, 90);
 
-  TH2F* mask_layer_chip = new TH2F("mask_layer_chip","mask_layer_chip",15,-0.5,14.5,16,-0.5,15.5);
-  TH2F* mask_layer = new TH2F("mask_layer","mask_layer",15,-0.5,14.5,20,-0.5,20.5);
+  TH2F *mask_layer_chip = new TH2F("mask_layer_chip", "mask_layer_chip", 15, -0.5, 14.5, 16, -0.5, 15.5);
+  TH2F *mask_layer = new TH2F("mask_layer", "mask_layer", 15, -0.5, 14.5, 20, -0.5, 20.5);
+  TH1F *mask_rate = new TH1F("mask_rate", "mask_rate", 15, -0.5, 14.5);
 
   float totalmasked[15];
   float totalmasked_chip[15][16];
 
-  ofstream fout(filename_out+".txt",ios::out);
-  fout<<"#masked_chns_list layer chip chns (0=not masked, 1=masked)"<<endl;
-  int nslabs=15;
-  for(int islab=0; islab<nslabs; islab++) {
-    TString map_name="../mapping/fev10_chip_channel_x_y_mapping.txt";
-    
+  ofstream fout(filename_out + ".txt", ios::out);
+  fout << "#masked_chns_list layer chip chns (0=not masked, 1=masked)" << endl;
+  int nslabs = 15;
+  for (int islab = 0; islab < nslabs; islab++)
+  {
+    TString map_name = "../mapping/fev10_chip_channel_x_y_mapping.txt";
+
     ReadMap(map_name);
-    
-    totalmasked[islab]=0;
-    for(int ichip=0; ichip<16; ichip++) {
-      totalmasked_chip[islab][ichip]=0;
-      fout<<islab<<" "<<ichip;
-      for(int ichn=0; ichn<64; ichn++) {
-	if(detector.slab[0][islab].asu[0].skiroc[ichip].mask[ichn]==1) {
-	  totalmasked[islab]++;
-	  totalmasked_chip[islab][ichip]++;
-	}
-	
-	float msk= detector.slab[0][islab].asu[0].skiroc[ichip].mask[ichn];
-	if(msk>0) {
-	  mask_chip_chn->Fill(ichip,ichn);
-	  mask_x_y->Fill(map_pointX[ichip][ichn],map_pointY[ichip][ichn]);
-	}
-	fout<<" "<<detector.slab[0][islab].asu[0].skiroc[ichip].mask[ichn];
+
+    totalmasked[islab] = 0;
+    for (int ichip = 0; ichip < 16; ichip++)
+    {
+      totalmasked_chip[islab][ichip] = 0;
+      fout << islab << " " << ichip;
+      for (int ichn = 0; ichn < 64; ichn++)
+      {
+        if (detector.slab[0][islab].asu[0].skiroc[ichip].mask[ichn] == 1)
+        {
+          totalmasked[islab]++;
+          totalmasked_chip[islab][ichip]++;
+        }
+
+        float msk = detector.slab[0][islab].asu[0].skiroc[ichip].mask[ichn];
+        if (msk > 0)
+        {
+          mask_chip_chn->Fill(ichip, ichn);
+          mask_x_y->Fill(map_pointX[ichip][ichn], map_pointY[ichip][ichn]);
+        }
+        fout << " " << detector.slab[0][islab].asu[0].skiroc[ichip].mask[ichn];
       }
-      fout<<endl;
-      cout<< "Skiroc idx:"<<ichip<<"  Masked cells:"<<100.*totalmasked_chip[islab][ichip]/64.<<"%"<<endl;
-      mask_layer_chip->Fill(14-islab,ichip,totalmasked_chip[islab][ichip]+0.01);
-
+      fout << endl;
+      cout << "Skiroc idx:" << ichip << "  Masked cells:" << 100. * totalmasked_chip[islab][ichip] / 64. << "%" << endl;
+      mask_layer_chip->Fill(14 - islab, ichip, totalmasked_chip[islab][ichip] + 0.01);
     }
-    cout<< "TOTAL Masked cells:"<<100.*totalmasked[islab]/1024.<<"%"<<endl;
-    mask_layer->Fill(14-islab,100.*totalmasked[islab]/1024.);
-    
+    cout << "TOTAL Masked cells:" << 100. * totalmasked[islab] / 1024. << "%" << endl;
+    mask_layer->Fill(14 - islab, 100. * totalmasked[islab] / 1024.);
+    mask_rate->Fill(islab, 100. * totalmasked[islab] / 1024.);
   }
-  
 
-  TCanvas *canvas = new TCanvas("canvas_accum","canvas_accum",800,800);
+  TCanvas *canvas = new TCanvas("canvas_accum", "canvas_accum", 800, 800);
   gStyle->SetOptStat(0);
-  gStyle->SetPalette(kRainBow);//Cherry);
+  gStyle->SetPalette(kRainBow); // Cherry);
   gStyle->SetPadRightMargin(0.16);
 
-  canvas->Divide(2,2);
+  canvas->Divide(2, 2);
   canvas->cd(1);
   mask_chip_chn->GetXaxis()->SetTitle("CHIP");
   mask_chip_chn->GetYaxis()->SetTitle("CHANNEL");
@@ -73,18 +78,28 @@ void test_read_masked_channels_TB(TString filename="/mnt/HardDrive/beamData/asci
   mask_layer_chip->GetXaxis()->SetTitle("Layer");
   mask_layer_chip->GetYaxis()->SetTitle("CHIP");
   mask_layer_chip->GetZaxis()->SetTitle("masked channels");
-  mask_layer_chip->GetZaxis()->SetRangeUser(0,35);
+  mask_layer_chip->GetZaxis()->SetRangeUser(0, 35);
   mask_layer_chip->Draw("colz");
 
   canvas->cd(4);
-  mask_layer->GetXaxis()->SetTitle("Layer");
-  mask_layer->GetYaxis()->SetTitle("[%] of channels that are masked");
-  mask_layer->GetZaxis()->SetTitle("");
-  mask_layer->GetZaxis()->SetRangeUser(0,35);
-  mask_layer->Draw("col");
+  TPad *pad = new TPad("pad", "", 0, 0, 1, 1);
+  pad->SetGrid(0, 1);
+  pad->Draw();
+  mask_rate->SetMarkerStyle(20);
+  mask_rate->SetBarWidth(0.9);
+  mask_rate->SetFillColor(49);
+  mask_rate->SetTitle("Masked channels rate");
+  mask_rate->GetXaxis()->SetTitle("Layer");
+  mask_rate->GetYaxis()->SetTitle("[%] of channels that are masked");
+  mask_rate->GetYaxis()->SetRangeUser(0, 100);
+  mask_rate->Draw("HIST bar2");
 
+  // mask_layer->GetXaxis()->SetTitle("Layer");
+  // mask_layer->GetYaxis()->SetTitle("[%] of channels that are masked");
+  // mask_layer->GetZaxis()->SetTitle("");
+  // mask_layer->GetZaxis()->SetRangeUser(0,35);
+  // mask_layer->Draw("col");
 
-  canvas->Print(filename_out+".root");
-  canvas->Print(filename_out+".png");
-  
+  canvas->Print(filename_out + ".root");
+  canvas->Print(filename_out + ".png");
 }

--- a/SLBcommissioning/test_read_thresholds_summary.C
+++ b/SLBcommissioning/test_read_thresholds_summary.C
@@ -82,24 +82,29 @@ void test_read_thresholds_summary(TString filename = "15102021/Run_Settings_Data
       cout << endl;
     }
 
-    TCanvas *canvas = new TCanvas(TString::Format("canvas_%i", islab), TString::Format("canvas_%i", islab), 800, 1600);
+    TCanvas *canvas = new TCanvas(TString::Format("canvas_%i", islab), TString::Format("canvas_%i", islab), 500, 1000);
     gStyle->SetOptStat(0);
     gStyle->SetPalette(kLightTemperature); // RainBow);
     canvas->Divide(1, 2);
     canvas->cd(1);
+    gPad->SetRightMargin(0.15);
+    threshold_chip_chn_2[islab]->SetTitle(TString::Format("Layer %i Channel vs. Chip", islab));
     threshold_chip_chn_2[islab]->GetXaxis()->SetTitle("CHIP");
     threshold_chip_chn_2[islab]->GetYaxis()->SetTitle("CHANNEL");
+    threshold_chip_chn_2[islab]->GetZaxis()->SetTitle("Global Threshold");
     threshold_chip_chn_2[islab]->GetZaxis()->SetRangeUser(190, 240);
     threshold_chip_chn_2[islab]->Draw("colz");
     threshold_chip_chn[islab]->Draw("text0same");
 
     canvas->cd(2);
+    gPad->SetRightMargin(0.15);
+    threshold_x_y_2[islab]->SetTitle(TString::Format("Layer %i Theresholds and channel XY positions", islab));
     threshold_x_y_2[islab]->GetXaxis()->SetTitle("x");
     threshold_x_y_2[islab]->GetYaxis()->SetTitle("y");
     threshold_x_y_2[islab]->GetZaxis()->SetRangeUser(190, 240);
     threshold_x_y_2[islab]->Draw("colz");
     threshold_x_y[islab]->Draw("text0same");
-    canvas->Print(TString::Format("plots/thresholds_slbAdd%i.eps", islab));
+    canvas->Print(TString::Format("plots/thresholds_slbAdd%i.pdf", islab));
 
   }
 

--- a/SLBcommissioning/test_read_thresholds_summary.C
+++ b/SLBcommissioning/test_read_thresholds_summary.C
@@ -1,113 +1,121 @@
-//# Copyright 2020  Adrián Irles (IJCLab, CNRS/IN2P3)
+// # Copyright 2020  Adrián Irles (IJCLab, CNRS/IN2P3)
 
 #include "conf_struct.h"
 
-void test_read_thresholds_summary(TString filename="15102021/Run_Settings_DataTaking_TB2021_15102021_WRITENbyDAQ.txt", bool debug=true) {
-  //void test_read_thresholds_summary(TString filename="15102021/Run_Settings_it10.txt", bool debug=true) {
+void test_read_thresholds_summary(TString filename = "15102021/Run_Settings_DataTaking_TB2021_15102021_WRITENbyDAQ.txt", bool debug = true)
+{
+  // void test_read_thresholds_summary(TString filename="15102021/Run_Settings_it10.txt", bool debug=true) {
 
-  read_configuration_file(filename,false);
+  read_configuration_file(filename, false);
 
-  TH2F* threshold_chip_chn[15];
-  TH2F* threshold_x_y[15];
+  TH2F *threshold_chip_chn[15];
+  TH2F *threshold_x_y[15];
 
-  TH2F* threshold_chip_chn_2[15];
-  TH2F* threshold_x_y_2[15];
+  TH2F *threshold_chip_chn_2[15];
+  TH2F *threshold_x_y_2[15];
 
-  TH2F* threshold_layer_chip = new TH2F("threshold_chip_chn","threshold_chip_chn",23,12.5,35.5,16,-0.5,15.5);
+  TH2F *threshold_layer_chip = new TH2F("threshold_chip_chn", "threshold_chip_chn", 23, 12.5, 35.5, 16, -0.5, 15.5);
   int mapping_slab[15];
-  mapping_slab[0]=18;
-  mapping_slab[1]=23;
-  mapping_slab[2]=17;
-  mapping_slab[3]=22;//
-  mapping_slab[4]=25;
-  mapping_slab[5]=24;
-  mapping_slab[6]=31;
-  mapping_slab[7]=30;//
-  mapping_slab[8]=21;
-  mapping_slab[9]=20;//
-  mapping_slab[10]=19;//
-  mapping_slab[11]=15;
-  mapping_slab[12]=14;//
-  mapping_slab[13]=13;
-  mapping_slab[14]=16;
-  
-  
-  for(int islab=0; islab<15; islab++) {
-    TString map_name="../mapping/fev10_chip_channel_x_y_mapping.txt";
+  mapping_slab[0] = 18;
+  mapping_slab[1] = 23;
+  mapping_slab[2] = 17;
+  mapping_slab[3] = 22; //
+  mapping_slab[4] = 25;
+  mapping_slab[5] = 24;
+  mapping_slab[6] = 31;
+  mapping_slab[7] = 30; //
+  mapping_slab[8] = 21;
+  mapping_slab[9] = 20;  //
+  mapping_slab[10] = 19; //
+  mapping_slab[11] = 15;
+  mapping_slab[12] = 14; //
+  mapping_slab[13] = 13;
+  mapping_slab[14] = 16;
+
+  vector<int> thresholdVec;
+
+  for (int islab = 0; islab < 15; islab++)
+  {
+    TString map_name = "../mapping/fev10_chip_channel_x_y_mapping.txt";
 
     // the two cobs are equipped with slbAdds 2.08 and 2.12 (26th May 2020)
-    if(detector.slab[0][islab].add==8 || detector.slab[0][islab].add==12)
-      map_name="../mapping/fev11_cob_chip_channel_x_y_mapping.txt";
-    
+    if (detector.slab[0][islab].add == 6 || detector.slab[0][islab].add == 8)
+      map_name = "../mapping/fev11_cob_rotate_chip_channel_x_y_mapping.txt";
+
     ReadMap(map_name);
 
-    cout<<" ----------------------------------- "<<endl;
-    cout<<"SlbAdd: "<<islab<<endl;
+    cout << " ----------------------------------- " << endl;
+    cout << "SlbAdd: " << islab << endl;
 
-    threshold_chip_chn[islab]= new TH2F(TString::Format("threshold_chip_chn_%i",islab),TString::Format("threshold_chip_chn_%i",islab),16,-0.5,15.5,64,-0.5,63.5);
-    threshold_x_y[islab]= new TH2F(TString::Format("threshold_x_y_%i",islab),TString::Format("threshold_x_y_%i",islab),32,-90,90,32,-90,90);
+    threshold_chip_chn[islab] = new TH2F(TString::Format("threshold_chip_chn_%i", islab), TString::Format("threshold_chip_chn_%i", islab), 16, -0.5, 15.5, 64, -0.5, 63.5);
+    threshold_x_y[islab] = new TH2F(TString::Format("threshold_x_y_%i", islab), TString::Format("threshold_x_y_%i", islab), 32, -90, 90, 32, -90, 90);
 
-    threshold_chip_chn_2[islab]= new TH2F(TString::Format("threshold_chip_chn_global_%i",islab),TString::Format("threshold_chip_chn_global_%i",islab),16,-0.5,15.5,64,-0.5,63.5);
-    threshold_x_y_2[islab]= new TH2F(TString::Format("threshold_x_y_global_%i",islab),TString::Format("threshold_x_y_global_%i",islab),32,-90,90,32,-90,90);
-    
-    for(int ichip=0; ichip<16; ichip++) {
-      cout<<"   chip: "<<ichip<< "  global: "<< detector.slab[0][islab].asu[0].skiroc[ichip].threshold_dac<<" DAC"<<endl;
-      cout<<"   individual: ";
+    threshold_chip_chn_2[islab] = new TH2F(TString::Format("threshold_chip_chn_global_%i", islab), TString::Format("threshold_chip_chn_global_%i", islab), 16, -0.5, 15.5, 64, -0.5, 63.5);
+    threshold_x_y_2[islab] = new TH2F(TString::Format("threshold_x_y_global_%i", islab), TString::Format("threshold_x_y_global_%i", islab), 32, -90, 90, 32, -90, 90);
 
 
-      for(int ichn=0; ichn<64; ichn++) {
-	float th= -detector.slab[0][islab].asu[0].skiroc[ichip].chn_threshold_adj[ichn];
-	float th_glob= detector.slab[0][islab].asu[0].skiroc[ichip].threshold_dac;
+    for (int ichip = 0; ichip < 16; ichip++)
+    {
+      cout << "   chip: " << ichip << "  global: " << detector.slab[0][islab].asu[0].skiroc[ichip].threshold_dac << " DAC" << endl;
+      cout << "   individual: ";
+      thresholdVec.push_back(detector.slab[0][islab].asu[0].skiroc[ichip].threshold_dac);
 
-	cout<<th<<" ";
-	if(detector.slab[0][islab].asu[0].skiroc[ichip].mask[ichn]==0) {
-	  threshold_chip_chn[islab]->Fill(ichip,ichn,th);
-	  threshold_x_y[islab]->Fill(map_pointX[ichip][ichn],map_pointY[ichip][ichn],th);
+      for (int ichn = 0; ichn < 64; ichn++)
+      {
+        float th = -detector.slab[0][islab].asu[0].skiroc[ichip].chn_threshold_adj[ichn];
+        float th_glob = detector.slab[0][islab].asu[0].skiroc[ichip].threshold_dac;
 
-	  threshold_chip_chn_2[islab]->Fill(ichip,ichn,th_glob);
-	  threshold_x_y_2[islab]->Fill(map_pointX[ichip][ichn],map_pointY[ichip][ichn],th_glob); 
-	}
+        cout << th << " ";
+        if (detector.slab[0][islab].asu[0].skiroc[ichip].mask[ichn] == 0)
+        {
+          threshold_chip_chn[islab]->Fill(ichip, ichn, th);
+          threshold_x_y[islab]->Fill(map_pointX[ichip][ichn], map_pointY[ichip][ichn], th);
+
+          threshold_chip_chn_2[islab]->Fill(ichip, ichn, th_glob);
+          threshold_x_y_2[islab]->Fill(map_pointX[ichip][ichn], map_pointY[ichip][ichn], th_glob);
+        }
       }
-      if(mapping_slab[islab]>23) threshold_layer_chip->Fill(mapping_slab[islab],ichip,detector.slab[0][islab].asu[0].skiroc[ichip].threshold_dac-15);
-      else threshold_layer_chip->Fill(mapping_slab[islab],ichip,detector.slab[0][islab].asu[0].skiroc[ichip].threshold_dac);
-      cout<<endl;
+      if (mapping_slab[islab] > 23)
+        threshold_layer_chip->Fill(mapping_slab[islab], ichip, detector.slab[0][islab].asu[0].skiroc[ichip].threshold_dac - 15);
+      else
+        threshold_layer_chip->Fill(mapping_slab[islab], ichip, detector.slab[0][islab].asu[0].skiroc[ichip].threshold_dac);
+      cout << endl;
     }
 
-  
-    TCanvas *canvas = new TCanvas(TString::Format("canvas_%i",islab),TString::Format("canvas_%i",islab),800,1600);
+    TCanvas *canvas = new TCanvas(TString::Format("canvas_%i", islab), TString::Format("canvas_%i", islab), 800, 1600);
     gStyle->SetOptStat(0);
-    gStyle->SetPalette(kLightTemperature);//RainBow);
-    canvas->Divide(1,2);
+    gStyle->SetPalette(kLightTemperature); // RainBow);
+    canvas->Divide(1, 2);
     canvas->cd(1);
     threshold_chip_chn_2[islab]->GetXaxis()->SetTitle("CHIP");
     threshold_chip_chn_2[islab]->GetYaxis()->SetTitle("CHANNEL");
-    threshold_chip_chn_2[islab]->GetZaxis()->SetRangeUser(220,280);
+    threshold_chip_chn_2[islab]->GetZaxis()->SetRangeUser(190, 240);
     threshold_chip_chn_2[islab]->Draw("colz");
     threshold_chip_chn[islab]->Draw("text0same");
-    
+
     canvas->cd(2);
     threshold_x_y_2[islab]->GetXaxis()->SetTitle("x");
     threshold_x_y_2[islab]->GetYaxis()->SetTitle("y");
-    threshold_x_y_2[islab]->GetZaxis()->SetRangeUser(220,280);
+    threshold_x_y_2[islab]->GetZaxis()->SetRangeUser(190, 240);
     threshold_x_y_2[islab]->Draw("colz");
     threshold_x_y[islab]->Draw("text0same");
-    canvas->Print(TString::Format("thresholds_slbAdd%i.eps",islab));
-
+    canvas->Print(TString::Format("plots/thresholds_slbAdd%i.eps", islab));
 
   }
-  
 
-     TCanvas *canvas2 = new TCanvas("canvas2","canvas2",600,600);
-     gStyle->SetOptStat(0);
-     gStyle->SetPalette(kRainBow);//Cherry);
-     gStyle->SetPadRightMargin(0.16);
-     
-     canvas2->cd(1);
-     threshold_layer_chip->GetXaxis()->SetTitle("SLAB-ID");
-     threshold_layer_chip->GetYaxis()->SetTitle("CHIP");
-     threshold_layer_chip->GetZaxis()->SetTitle("Global Threshold");
-     threshold_layer_chip->GetZaxis()->SetRangeUser(200,280);
-     threshold_layer_chip->Draw("colz");
+  const auto [min, max] = std::minmax_element(begin(thresholdVec), end(thresholdVec));
+  std::cout << "min = " << *min << ", max = " << *max << '\n';
 
-  
+
+  TCanvas *canvas2 = new TCanvas("canvas2", "canvas2", 600, 600);
+  gStyle->SetOptStat(0);
+  gStyle->SetPalette(kRainBow); // Cherry);
+  gStyle->SetPadRightMargin(0.16);
+
+  canvas2->cd(1);
+  threshold_layer_chip->GetXaxis()->SetTitle("SLAB-ID");
+  threshold_layer_chip->GetYaxis()->SetTitle("CHIP");
+  threshold_layer_chip->GetZaxis()->SetTitle("Global Threshold");
+  threshold_layer_chip->GetZaxis()->SetRangeUser(200, 280);
+  threshold_layer_chip->Draw("colz");
 }

--- a/SLBcommissioning/test_read_thresholds_summary2.C
+++ b/SLBcommissioning/test_read_thresholds_summary2.C
@@ -95,6 +95,9 @@ void test_read_thresholds_summary2(TString filename="/mnt/win2/Run_Data/Run_ILC_
 
   }
   
+     gStyle->SetPadTickX(1);
+     gStyle->SetPadTickY(1);
+     gROOT->ForceStyle();
 
      TCanvas *canvas2 = new TCanvas("canvas2","canvas2",600,600);
      gStyle->SetOptStat(0);
@@ -102,11 +105,15 @@ void test_read_thresholds_summary2(TString filename="/mnt/win2/Run_Data/Run_ILC_
      gStyle->SetPadRightMargin(0.16);
      
      canvas2->cd(1);
-     threshold_layer_chip->GetXaxis()->SetTitle("SLAB-ID");
+     canvas2->SetRightMargin(0.16);
+     threshold_layer_chip->SetTitle("Common Thresholds");
+     threshold_layer_chip->GetXaxis()->SetTitle("Layer");
      threshold_layer_chip->GetYaxis()->SetTitle("CHIP");
      threshold_layer_chip->GetZaxis()->SetTitle("Global Threshold");
+      threshold_layer_chip->GetZaxis()->SetTitleOffset(1.4);
      //     threshold_layer_chip->GetZaxis()->SetRangeUser(200,300);
      threshold_layer_chip->Draw("colz");
+     gPad->RedrawAxis();
 
   
 }

--- a/SLBcommissioning/thresholds/fithistos.C
+++ b/SLBcommissioning/thresholds/fithistos.C
@@ -14,366 +14,402 @@
 
 #include "../conf_struct.h"
 
-//#include "../../style/Style.C"
-//#include "../../style/Labels.C"
+// #include "../../style/Style.C"
+// #include "../../style/Labels.C"
 
 using namespace std;
 
-int nslabs=15;
-int nchips=16;
-int nchannels=64;
-int nchannels_fit=6;
+int nslabs = 15;
+int nchips = 16;
+int nchannels = 64;
+int nchannels_fit = 6;
 
-
-Float_t charge_low[16][64]; //daughter, slab, asic, chn, DAC
-Float_t charge_high[16][64]; //daughter, slab, asic, chn, DAC
+Float_t charge_low[16][64];  // daughter, slab, asic, chn, DAC
+Float_t charge_high[16][64]; // daughter, slab, asic, chn, DAC
 void ReadCharge(TString filename)
-  
+
 {
   /*
     === RATE Vs THRESHOLD HISTO SAVED WITH ILC SL-SOFTWARE VERSION: V2.10  == DATE OF SCAN: UnixTime = 1576752746.986 date = 2019.12.19 ===
     === SL_COREMODULE_INTERFACE SerNum 2.41A FPGA Version V2.1.11 == NB OF CORE DAUGHTERS: 1 ===
     ====== CORE DAUGHTER 0 == FPGA Version V1.2.6 == NB OF CONNECTED SLABs 1 ======
     ========= DAUGHTER 0 == SLAB 0 == SL BOARD ADD 3 == FPGA Version V1.3.4 == NB OF CONNECTED ASUs 1 =========
-    === Hit Rate Vs Threshold Scan,for All Channels modulo 64 at once, AcqWindow 2 ms, MinThreshold = 170, MaxThreshold= 240, Nb Of Steps: 7, Nb Of Cycles per Step= 5 === 
+    === Hit Rate Vs Threshold Scan,for All Channels modulo 64 at once, AcqWindow 2 ms, MinThreshold = 170, MaxThreshold= 240, Nb Of Steps: 7, Nb Of Cycles per Step= 5 ===
   */
 
-
- 
- 
-  cout<<"Reading scurve file: "<<filename<<endl;
+  cout << "Reading scurve file: " << filename << endl;
   std::ifstream reading_file(filename);
-  if(!reading_file){
-    std::cout<<"NO FILE!!"<<std::endl;
+  if (!reading_file)
+  {
+    std::cout << "NO FILE!!" << std::endl;
   }
-  for(int i=0; i<nchips; i++) {
-    for(int j=0; j<nchannels; j++) {
+  for (int i = 0; i < nchips; i++)
+  {
+    for (int j = 0; j < nchannels; j++)
+    {
       charge_low[i][j] = 0.;
       charge_high[i][j] = 0.;
     }
   }
-  
+
   std::string line;
 
   // check Firstline
   getline(reading_file, line);
 
-  int ichn=-1, ski=-1;
-  int gain=-1;
-  while( getline(reading_file,line) ) {
-    search_string_nocolon(line,"Skiroc",ski);
-    search_string_nocolon(line,"Ch",ichn);
+  int ichn = -1, ski = -1;
+  int gain = -1;
+  while (getline(reading_file, line))
+  {
+    search_string_nocolon(line, "Skiroc", ski);
+    search_string_nocolon(line, "Ch", ichn);
 
-    if(ski>-1 && ichn>-1) {
-      //Low gain
-      getline(reading_file,line);
-      search_string_nocolon(line,"Gain",gain);
-      getline(reading_file,line);
+    if (ski > -1 && ichn > -1)
+    {
+      // Low gain
+      getline(reading_file, line);
+      search_string_nocolon(line, "Gain", gain);
+      getline(reading_file, line);
       std::string space_delimiter = " ";
       size_t pos = 0;
       int i = 0;
-      int scas=0;
-      while ((pos = line.find(space_delimiter)) != string::npos) {
-	if(i>14) break;
-	float tmp=0;
-	try {
-	  tmp  = std::stof(line.substr(0, pos));
-	} catch(std::invalid_argument e){ tmp=0;};
-	  
-	if(tmp>0) {
-	  charge_low[ski][ichn]+=tmp;
-	  scas++;
-	}
-	line.erase(0, pos + space_delimiter.length());
-	i++;
-      }
-      //High gain
-      //cout<<"HG "<<line<<endl;
+      int scas = 0;
+      while ((pos = line.find(space_delimiter)) != string::npos)
+      {
+        if (i > 14)
+          break;
+        float tmp = 0;
+        try
+        {
+          tmp = std::stof(line.substr(0, pos));
+        }
+        catch (std::invalid_argument e)
+        {
+          tmp = 0;
+        };
 
-      getline(reading_file,line);
-      search_string_nocolon(line,"Gain",gain);
-      getline(reading_file,line);
+        if (tmp > 0)
+        {
+          charge_low[ski][ichn] += tmp;
+          scas++;
+        }
+        line.erase(0, pos + space_delimiter.length());
+        i++;
+      }
+      // High gain
+      // cout<<"HG "<<line<<endl;
+
+      getline(reading_file, line);
+      search_string_nocolon(line, "Gain", gain);
+      getline(reading_file, line);
       space_delimiter = " ";
       pos = 0;
       i = 0;
-      scas=0;
+      scas = 0;
       //	cout<<line<<endl;
-      while ((pos = line.find(space_delimiter)) != string::npos) {
-	if(i>15) break;
-	float tmp=0;
-	try {
-	  tmp  = std::stof(line.substr(0, pos));
-	} catch(std::invalid_argument e){ tmp=0;};
-	if(tmp>0) {
-	  charge_high[ski][ichn]+=tmp;
-	  scas++;
-	}
-	line.erase(0, pos + space_delimiter.length());
-	i++;
+      while ((pos = line.find(space_delimiter)) != string::npos)
+      {
+        if (i > 15)
+          break;
+        float tmp = 0;
+        try
+        {
+          tmp = std::stof(line.substr(0, pos));
+        }
+        catch (std::invalid_argument e)
+        {
+          tmp = 0;
+        };
+        if (tmp > 0)
+        {
+          charge_high[ski][ichn] += tmp;
+          scas++;
+        }
+        line.erase(0, pos + space_delimiter.length());
+        i++;
       }
-      if(scas>0) charge_high[ski][ichn]/=scas;
+      if (scas > 0)
+        charge_high[ski][ichn] /= scas;
       //      cout<<scas<<" "<<charge_high[ski][ichn]<<endl;
     }
   }
-
-
 }
 
 float FirstZero(TGraphErrors *gr)
 {
 
-
-  int imax = TMath::LocMax(gr->GetN(),gr->GetY()); 
-  Double_t xmax,ymax;
+  int imax = TMath::LocMax(gr->GetN(), gr->GetY());
+  Double_t xmax, ymax;
   gr->GetPoint(imax, xmax, ymax);
 
-  //if(imax==0) return 0;
+  // if(imax==0) return 0;
 
-  for(int i=imax; i<gr->GetN(); i++) {
+  for (int i = imax; i < gr->GetN(); i++)
+  {
     gr->GetPoint(i, xmax, ymax);
-    if(ymax<0.05) return xmax;
+    if (ymax < 0.05)
+      return xmax;
   }
 
   return 0;
-  
 }
 
-TF1 *FitScurve(TGraphErrors *gr, float xmin_=200, float xmax_=350, float x0=200)
+TF1 *FitScurve(TGraphErrors *gr, float xmin_ = 200, float xmax_ = 350, float x0 = 200)
 {
-   
-  double par1=0, par2=0, par3=0;
 
-  int imax = TMath::LocMax(gr->GetN(),gr->GetY());
-  int n=gr->GetN();
-  double* x = gr->GetX();
-  double* y = gr->GetY();
+  double par1 = 0, par2 = 0, par3 = 0;
 
-  if(n==0 || y[imax]==0) return NULL;
+  int imax = TMath::LocMax(gr->GetN(), gr->GetY());
+  int n = gr->GetN();
+  double *x = gr->GetX();
+  double *y = gr->GetY();
 
-  double xmin = FirstZero(gr)-15;//max(x[imax],x[n/3])-5;
-  double xmax = FirstZero(gr)+15;
+  if (n == 0 || y[imax] == 0)
+    return NULL;
+
+  double xmin = FirstZero(gr) - 15; // max(x[imax],x[n/3])-5;
+  double xmax = FirstZero(gr) + 15;
 
   double ymax = y[imax];
 
   //  std::cout<<"  ----------- 1 "<<endl;
 
-  TF1 *fit1 = new TF1("fit1","[0]*TMath::Erfc((x-[1])/(sqrt(2)*[2]))",xmin,xmax);
+  TF1 *fit1 = new TF1("fit1", "[0]*TMath::Erfc((x-[1])/(sqrt(2)*[2]))", xmin, xmax);
 
-  fit1->SetParLimits(0,ymax*0.1,ymax*10);
-  fit1->SetParLimits(1,xmin_,xmax_);
+  fit1->SetParLimits(0, ymax * 0.1, ymax * 10);
+  fit1->SetParLimits(1, xmin_, xmax_);
 
-  fit1->SetParameter(0,ymax);
+  fit1->SetParameter(0, ymax);
   // fit1->SetParameter(1,250);
-  fit1->SetParameter(2,3); 
-  gr->Fit("fit1","QR");
+  fit1->SetParameter(2, 3);
+  gr->Fit("fit1", "QR");
 
-  par1=fit1->GetParameter(0); 
-  par2=fit1->GetParameter(1); 
-  par3=fit1->GetParameter(2);
-
+  par1 = fit1->GetParameter(0);
+  par2 = fit1->GetParameter(1);
+  par3 = fit1->GetParameter(2);
 
   // std::cout<<par1<<" "<<par2<<" "<<par3<<endl;
 
   //  std::cout<<"  ----------- 2 "<<endl;
 
-  //if(par2<185) par2=190;
-  //  if(par3<1) par3=1.5;
-  xmin=max(par2-8*par3,x[n/3]);
-  xmax=par2+20*par3;
-  TF1 *fit2 = new TF1("fit2","[0]*TMath::Erfc((x-[1])/[2]+[3])",xmin,xmax);
+  // if(par2<185) par2=190;
+  //   if(par3<1) par3=1.5;
+  xmin = max(par2 - 8 * par3, x[n / 3]);
+  xmax = par2 + 20 * par3;
+  TF1 *fit2 = new TF1("fit2", "[0]*TMath::Erfc((x-[1])/[2]+[3])", xmin, xmax);
 
-  fit2->SetParLimits(0,par1*0.3,par1+par1*0.5);
-  fit2->SetParLimits(1,xmin_,xmax_);
-  fit2->SetParLimits(2,1.5,10);
+  fit2->SetParLimits(0, par1 * 0.3, par1 + par1 * 0.5);
+  fit2->SetParLimits(1, xmin_, xmax_);
+  fit2->SetParLimits(2, 1.5, 10);
 
   /* fit2->SetParameter(0,0.5*ymax);
      fit2->SetParameter(1,200);
      fit2->SetParameter(2,10); */
-  fit2->SetParameter(0,par1);
-  fit2->SetParameter(1,par2);
-  fit2->SetParameter(2,par3);
-  gr->Fit("fit2","QR");
-    
+  fit2->SetParameter(0, par1);
+  fit2->SetParameter(1, par2);
+  fit2->SetParameter(2, par3);
+  gr->Fit("fit2", "QR");
+
   return fit2;
 }
 
-void fithistos(){
+void fithistos()
+{
 
-
-  read_configuration_file("Run_Settings_090185.txt",false);
-  double dac_value[15][16]={0};
-  double dac_value_p10[15][16]={0};
-  double dac_value_p20[15][16]={0};
-  for(int islab=0; islab<nslabs; islab++) {
-    for(int ichip=0; ichip<nchips; ichip++) {
-      double nchn=0;
-      double th=0;
-      for(int ichn=0; ichn<nchannels; ichn++) {
-	if(detector.slab[0][islab].asu[0].skiroc[ichip].mask[ichn]==0 ){
-	  th+=(detector.slab[0][islab].asu[0].skiroc[ichip].threshold_dac - detector.slab[0][islab].asu[0].skiroc[ichip].chn_threshold_adj[ichn]);
-	  nchn++;
-	}
+  read_configuration_file("Run_Settings_090185.txt", false);
+  double dac_value[15][16] = {0};
+  double dac_value_p10[15][16] = {0};
+  double dac_value_p20[15][16] = {0};
+  for (int islab = 0; islab < nslabs; islab++)
+  {
+    for (int ichip = 0; ichip < nchips; ichip++)
+    {
+      double nchn = 0;
+      double th = 0;
+      for (int ichn = 0; ichn < nchannels; ichn++)
+      {
+        if (detector.slab[0][islab].asu[0].skiroc[ichip].mask[ichn] == 0)
+        {
+          th += (detector.slab[0][islab].asu[0].skiroc[ichip].threshold_dac - detector.slab[0][islab].asu[0].skiroc[ichip].chn_threshold_adj[ichn]);
+          nchn++;
+        }
       }
-      if(nchn!=0) th/=nchn;
-      dac_value[islab][ichip]=th;
-      dac_value_p10[islab][ichip]=th+10.;
-      dac_value_p20[islab][ichip]=th+20.;
+      if (nchn != 0)
+        th /= nchn;
+      dac_value[islab][ichip] = th;
+      dac_value_p10[islab][ichip] = th + 10.;
+      dac_value_p20[islab][ichip] = th + 20.;
     }
   }
 
-  int slabsorting[16]={4,8,3,7,2,6,1,5,12,16,11,15,10,14,9,13};
+  int slabsorting[16] = {4, 8, 3, 7, 2, 6, 1, 5, 12, 16, 11, 15, 10, 14, 9, 13};
 
-  double xtest2[2]={0.5,0.5};
-  double ytest2[2]={0,400};
-  TGraph* g_test2= new TGraph(2,xtest2,ytest2);
+  double xtest2[2] = {0.5, 0.5};
+  double ytest2[2] = {0, 400};
+  TGraph *g_test2 = new TGraph(2, xtest2, ytest2);
 
-  double xtest3[2]={0.75,0.75};
-  double ytest3[2]={0,400};
-  TGraph* g_test3= new TGraph(2,xtest3,ytest3);
+  double xtest3[2] = {0.75, 0.75};
+  double ytest3[2] = {0, 400};
+  TGraph *g_test3 = new TGraph(2, xtest3, ytest3);
 
-  double xtest4[2]={1,1};
-  double ytest4[2]={0,400};
-  TGraph* g_test4= new TGraph(2,xtest4,ytest4);
-  
-  TCanvas * c_dac_vs_mip[15];
-  for(int i=0; i<nslabs; i++) {
-    c_dac_vs_mip[i] = new TCanvas(TString::Format("slab_%i",i),TString::Format("slab_%i",i),1200,900);
-    c_dac_vs_mip[i]->Divide(4,4);
+  double xtest4[2] = {1, 1};
+  double ytest4[2] = {0, 400};
+  TGraph *g_test4 = new TGraph(2, xtest4, ytest4);
+
+  TCanvas *c_dac_vs_mip[15];
+  for (int i = 0; i < nslabs; i++)
+  {
+    c_dac_vs_mip[i] = new TCanvas(TString::Format("slab_%i", i), TString::Format("slab_%i", i), 1200, 900);
+    c_dac_vs_mip[i]->Divide(4, 4);
   }
 
   TF1 *scurvefit[10][15][16][4];
 
-    
-  for(int ifile=0; ifile<4; ifile++) {
-    TString filename="injection_3p0high_chn0to8";
-    if(ifile==1) filename="injection_3p05high_chn0to8";
-    if(ifile==2) filename="injection_3p1high_chn0to8";
-    if(ifile==3) filename="injection_3p2high_chn0to8";
-    
-    
+  for (int ifile = 0; ifile < 4; ifile++)
+  {
+    TString filename = "injection_3p0high_chn0to8";
+    if (ifile == 1)
+      filename = "injection_3p05high_chn0to8";
+    if (ifile == 2)
+      filename = "injection_3p1high_chn0to8";
+    if (ifile == 3)
+      filename = "injection_3p2high_chn0to8";
+
     TGraphErrors *scurve[15][16][4];
-    
-    TFile *file_summary = new TFile("histos/scurves_"+filename+".root" , "READ");
-    
+
+    TFile *file_summary = new TFile("histos/scurves_" + filename + ".root", "READ");
+
     file_summary->cd();
-    for(int i=0; i<nslabs; i++) {
-      for(int iasic=0; iasic<nchips; iasic++) {
-	for(int ichn=0; ichn<nchannels_fit; ichn++) {
-	  
-	  scurve[i][iasic][ichn]=(TGraphErrors*)file_summary->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i",i,iasic,ichn));
-	  scurvefit[ifile][i][iasic][ichn]=FitScurve(scurve[i][iasic][ichn]);
-	}
+    for (int i = 0; i < nslabs; i++)
+    {
+      for (int iasic = 0; iasic < nchips; iasic++)
+      {
+        for (int ichn = 0; ichn < nchannels_fit; ichn++)
+        {
+
+          scurve[i][iasic][ichn] = (TGraphErrors *)file_summary->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i", i, iasic, ichn));
+          scurvefit[ifile][i][iasic][ichn] = FitScurve(scurve[i][iasic][ichn]);
+        }
       }
     }
   }
-  cout<<" AAA "<<endl;  
-  TFile *file_summary2 = new TFile("../../mip_calib/MIPSummary_pedestalsubmode1_raw_siwecal_90021to90070_highgain.root" , "READ");
-  for(int i=0; i<nslabs; i++) {
+  cout << " AAA " << endl;
+  TFile *file_summary2 = new TFile("../../mip_calib/MIPSummary_pedestalsubmode1_raw_siwecal_90021to90070_highgain.root", "READ");
+  for (int i = 0; i < nslabs; i++)
+  {
 
-    for(int iasic=0; iasic<nchips; iasic++) {
+    for (int iasic = 0; iasic < nchips; iasic++)
+    {
 
-      TH1F *h_temp=(TH1F*)file_summary2->Get(TString::Format("layer_%i/mip_high_layer%i_chip%i",i,i,iasic));
-      TF1 * f_temp=h_temp->GetFunction(TString::Format("Fitfcn_mip_high_layer%i_chip%i",i,iasic));
-      float mpv=9999999.;
-      float empv=0.;
+      TH1F *h_temp = (TH1F *)file_summary2->Get(TString::Format("layer_%i/mip_high_layer%i_chip%i", i, i, iasic));
+      TF1 *f_temp = h_temp->GetFunction(TString::Format("Fitfcn_mip_high_layer%i_chip%i", i, iasic));
+      float mpv = 9999999.;
+      float empv = 0.;
 
-      if(f_temp!=NULL) {
-	mpv=f_temp->GetParameter(1);
-	if(mpv<2) mpv=999999.;
-	empv=f_temp->GetParameter(0);
+      if (f_temp != NULL)
+      {
+        mpv = f_temp->GetParameter(1);
+        if (mpv < 2)
+          mpv = 999999.;
+        empv = f_temp->GetParameter(0);
       }
 
       c_dac_vs_mip[i]->cd(slabsorting[iasic]);
-      TGraphErrors * dac_vs_mip[8];
-      for(int ichn=0; ichn<nchannels_fit; ichn++) {
-	double x[10]={0}, y[10]={0}, ex[10]={0}, ey[10]={0};
+      TGraphErrors *dac_vs_mip[8];
+      for (int ichn = 0; ichn < nchannels_fit; ichn++)
+      {
+        double x[10] = {0}, y[10] = {0}, ex[10] = {0}, ey[10] = {0};
 
-	int nfiles=0;
-	for(int ifile=0; ifile<4; ifile++) {
-	  TString filename="injection_3p0high_chn0to8";
-	  if(ifile==1) filename="injection_3p05high_chn0to8";
-	  if(ifile==2) filename="injection_3p1high_chn0to8";
-	  if(ifile==3) filename="injection_3p2high_chn0to8";
-	  TString filename_input =filename+TString::Format("/ChargeMeanValues_Core0_SlabAdd%i_Asu0.txt",i);
-	  ReadCharge(filename_input);
-	  if(scurvefit[ifile][i][iasic][ichn]!=NULL) {
-	    y[ifile]=scurvefit[ifile][i][iasic][ichn]->GetParameter(1);
-	    ey[ifile]=scurvefit[ifile][i][iasic][ichn]->GetParError(1);
-	    
-	    x[ifile]=charge_high[iasic][ichn]/mpv;
-	    ex[ifile]=empv/mpv;//chargefit[ifile][i][iasic][ichn]->GetParameter(2);
-	    nfiles++;
-	  } 
-	}
-                
-	dac_vs_mip[ichn]= new TGraphErrors(nfiles,x,y,ex,ey);
-	dac_vs_mip[ichn]->SetLineColor(ichn+1);
-	dac_vs_mip[ichn]->SetMarkerColor(ichn+1);
-	dac_vs_mip[ichn]->SetMarkerStyle(ichn+20);
-	if(ichn==0) {
-	  double xtest[2]={0,2.5};
-	  double ytest[2]={180,300};
-	  TGraph* g_test= new TGraph(2,xtest,ytest);
-	  g_test->SetLineColor(0);
-	  g_test->SetTitle(TString::Format("Layer:%i, ASIC:%i",i,iasic));
-	  g_test->GetYaxis()->SetTitle("DAC");
-	  g_test->GetYaxis()->SetTitleOffset(1);
-	  g_test->GetYaxis()->SetTitleSize(0.05);
-	  g_test->GetYaxis()->SetLabelSize(0.05);
-	  g_test->GetXaxis()->SetTitle("MIP");
-	  g_test->GetXaxis()->SetTitleSize(0.05);
-	  g_test->GetXaxis()->SetLabelSize(0.05);
+        int nfiles = 0;
+        for (int ifile = 0; ifile < 4; ifile++)
+        {
+          TString filename = "injection_3p0high_chn0to8";
+          if (ifile == 1)
+            filename = "injection_3p05high_chn0to8";
+          if (ifile == 2)
+            filename = "injection_3p1high_chn0to8";
+          if (ifile == 3)
+            filename = "injection_3p2high_chn0to8";
+          TString filename_input = filename + TString::Format("/ChargeMeanValues_Core0_SlabAdd%i_Asu0.txt", i);
+          ReadCharge(filename_input);
+          if (scurvefit[ifile][i][iasic][ichn] != NULL)
+          {
+            y[ifile] = scurvefit[ifile][i][iasic][ichn]->GetParameter(1);
+            ey[ifile] = scurvefit[ifile][i][iasic][ichn]->GetParError(1);
 
-	  double xdac[2]={0,2.5};
-          double ydac[2]={dac_value[i][iasic],dac_value[i][iasic]};
-          TGraph* g_dac= new TGraph(2,xdac,ydac);
+            x[ifile] = charge_high[iasic][ichn] / mpv;
+            ex[ifile] = empv / mpv; // chargefit[ifile][i][iasic][ichn]->GetParameter(2);
+            nfiles++;
+          }
+        }
 
-	  double xdac2[2]={0,2.5};
-          double ydac2[2]={dac_value_p10[i][iasic],dac_value_p10[i][iasic]};
-          TGraph* g_dac2= new TGraph(2,xdac2,ydac2);
+        dac_vs_mip[ichn] = new TGraphErrors(nfiles, x, y, ex, ey);
+        dac_vs_mip[ichn]->SetLineColor(ichn + 1);
+        dac_vs_mip[ichn]->SetMarkerColor(ichn + 1);
+        dac_vs_mip[ichn]->SetMarkerStyle(ichn + 20);
+        if (ichn == 0)
+        {
+          double xtest[2] = {0, 2.5};
+          double ytest[2] = {180, 300};
+          TGraph *g_test = new TGraph(2, xtest, ytest);
+          g_test->SetLineColor(0);
+          g_test->SetTitle(TString::Format("Layer:%i, ASIC:%i", i, iasic));
+          g_test->GetYaxis()->SetTitle("DAC");
+          g_test->GetYaxis()->SetTitleOffset(1);
+          g_test->GetYaxis()->SetTitleSize(0.05);
+          g_test->GetYaxis()->SetLabelSize(0.05);
+          g_test->GetXaxis()->SetTitle("MIP");
+          g_test->GetXaxis()->SetTitleSize(0.05);
+          g_test->GetXaxis()->SetLabelSize(0.05);
 
-	  double xdac3[2]={0,2.5};
-          double ydac3[2]={dac_value_p20[i][iasic],dac_value_p20[i][iasic]};
-          TGraph* g_dac3= new TGraph(2,xdac3,ydac3);
+          double xdac[2] = {0, 2.5};
+          double ydac[2] = {dac_value[i][iasic], dac_value[i][iasic]};
+          TGraph *g_dac = new TGraph(2, xdac, ydac);
 
-	  g_test->Draw("al");
-	  g_dac->SetLineColor(2);
+          double xdac2[2] = {0, 2.5};
+          double ydac2[2] = {dac_value_p10[i][iasic], dac_value_p10[i][iasic]};
+          TGraph *g_dac2 = new TGraph(2, xdac2, ydac2);
+
+          double xdac3[2] = {0, 2.5};
+          double ydac3[2] = {dac_value_p20[i][iasic], dac_value_p20[i][iasic]};
+          TGraph *g_dac3 = new TGraph(2, xdac3, ydac3);
+
+          g_test->Draw("al");
+          g_dac->SetLineColor(2);
           g_dac->SetLineStyle(1);
           g_dac->SetLineWidth(3);
           g_dac->Draw("l");
 
-	  g_dac2->SetLineColor(2);
+          g_dac2->SetLineColor(2);
           g_dac2->SetLineStyle(1);
           g_dac2->SetLineWidth(2);
           g_dac2->Draw("l");
 
-	  g_dac3->SetLineColor(2);
+          g_dac3->SetLineColor(2);
           g_dac3->SetLineStyle(1);
           g_dac3->SetLineWidth(1);
           g_dac3->Draw("l");
 
-	  g_test2->SetLineColor(1);
-	  g_test2->SetLineStyle(2);
-	  g_test2->SetLineWidth(3);
-	  g_test2->Draw("l");
-	  g_test3->SetLineColor(1);
+          g_test2->SetLineColor(1);
+          g_test2->SetLineStyle(2);
+          g_test2->SetLineWidth(3);
+          g_test2->Draw("l");
+          g_test3->SetLineColor(1);
           g_test3->SetLineStyle(2);
           g_test3->SetLineWidth(2);
           g_test3->Draw("l");
-	  g_test4->SetLineColor(1);
-	  g_test4->SetLineStyle(2);
-	  g_test4->SetLineWidth(1);
-	  g_test4->Draw("l");
-	}
-	dac_vs_mip[ichn]->Draw("lp");
+          g_test4->SetLineColor(1);
+          g_test4->SetLineStyle(2);
+          g_test4->SetLineWidth(1);
+          g_test4->Draw("l");
+        }
+        dac_vs_mip[ichn]->Draw("lp");
       }
     }
   }
 
-  
-  for(int i=0; i<nslabs; i++) {
-    c_dac_vs_mip[i]->Print(TString::Format("slab_%i.pdf",i));
+  for (int i = 0; i < nslabs; i++)
+  {
+    c_dac_vs_mip[i]->Print(TString::Format("slab_%i.pdf", i));
   }
 }
-
-

--- a/SLBcommissioning/thresholds/fithistos.C
+++ b/SLBcommissioning/thresholds/fithistos.C
@@ -176,7 +176,8 @@ TF1 *FitScurve(TGraphErrors *gr, float xmin_ = 200, float xmax_ = 350, float x0 
 
   TF1 *fit1 = new TF1("fit1", "[0]*TMath::Erfc((x-[1])/(sqrt(2)*[2]))", xmin, xmax);
 
-  fit1->SetParLimits(0, ymax * 0.1, ymax * 10);
+  // fit1->SetParLimits(0, ymax * 0.1, ymax * 10);
+  fit1->SetParLimits(0, 0, ymax * 1.5);
   fit1->SetParLimits(1, xmin_, xmax_);
 
   fit1->SetParameter(0, ymax);
@@ -286,7 +287,6 @@ void fithistos()
       {
         for (int ichn = 0; ichn < nchannels_fit; ichn++)
         {
-
           scurve[i][iasic][ichn] = (TGraphErrors *)file_summary->Get(TString::Format("scurve_slbAdd%i_chip%i_chn%i", i, iasic, ichn));
           scurvefit[ifile][i][iasic][ichn] = FitScurve(scurve[i][iasic][ichn]);
         }

--- a/SLBcommissioning/thresholds/fithistos.C
+++ b/SLBcommissioning/thresholds/fithistos.C
@@ -24,6 +24,24 @@ int nchips = 16;
 int nchannels = 64;
 int nchannels_fit = 6;
 
+void print_current_progress(int progress, int total_progress)
+{
+  int barWidth = 70;
+  std::cout << "Progress: [";
+  int pos = barWidth * progress / total_progress;
+  for (int i = 0; i < barWidth; ++i)
+  {
+    if (i < pos)
+      std::cout << "=";
+    else if (i == pos)
+      std::cout << ">";
+    else
+      std::cout << " ";
+  }
+  std::cout << "] " << int(progress * 100. / total_progress) << " %\r";
+  std::cout.flush();
+}
+
 Float_t charge_low[16][64];  // daughter, slab, asic, chn, DAC
 Float_t charge_high[16][64]; // daughter, slab, asic, chn, DAC
 void ReadCharge(TString filename)
@@ -37,7 +55,7 @@ void ReadCharge(TString filename)
     === Hit Rate Vs Threshold Scan,for All Channels modulo 64 at once, AcqWindow 2 ms, MinThreshold = 170, MaxThreshold= 240, Nb Of Steps: 7, Nb Of Cycles per Step= 5 ===
   */
 
-  cout << "Reading scurve file: " << filename << endl;
+  // cout << "Reading scurve file: " << filename << endl;
   std::ifstream reading_file(filename);
   if (!reading_file)
   {
@@ -217,7 +235,8 @@ TF1 *FitScurve(TGraphErrors *gr, float xmin_ = 200, float xmax_ = 350, float x0 
 void fithistos()
 {
 
-  read_configuration_file("Run_Settings_090185.txt", false);
+  // read_configuration_file("Run_Settings_090185.txt", false);
+  read_configuration_file("../../../simulation/masking/Run_Settings/Run_Settings_90320_e-_10.0GeV.txt", false);
   double dac_value[15][16] = {0};
   double dac_value_p10[15][16] = {0};
   double dac_value_p20[15][16] = {0};
@@ -293,8 +312,12 @@ void fithistos()
       }
     }
   }
-  cout << " AAA " << endl;
-  TFile *file_summary2 = new TFile("../../mip_calib/MIPSummary_pedestalsubmode1_raw_siwecal_90021to90070_highgain.root", "READ");
+  // TFile *file_summary2 = new TFile("../../mip_calib/MIPSummary_pedestalsubmode1_raw_siwecal_90021to90070_highgain.root", "READ");
+  TFile *file_summary2 = new TFile("../../mip_calib/MIPSummary_pedestalsubmode1_raw_siwecal_90259to90285_highgain.root", "READ");
+
+  int total_progress = nslabs * nchips * nchannels_fit * 4;
+  int progress = 0;
+
   for (int i = 0; i < nslabs; i++)
   {
 
@@ -323,6 +346,9 @@ void fithistos()
         int nfiles = 0;
         for (int ifile = 0; ifile < 4; ifile++)
         {
+          progress++;
+          print_current_progress(progress, total_progress);          
+
           TString filename = "injection_3p0high_chn0to8";
           if (ifile == 1)
             filename = "injection_3p05high_chn0to8";
@@ -410,6 +436,6 @@ void fithistos()
 
   for (int i = 0; i < nslabs; i++)
   {
-    c_dac_vs_mip[i]->Print(TString::Format("slab_%i.pdf", i));
+    c_dac_vs_mip[i]->Print(TString::Format("plots/slab_%i.pdf", i));
   }
 }

--- a/SLBperformance/TBchecks/analysis.h
+++ b/SLBperformance/TBchecks/analysis.h
@@ -99,6 +99,7 @@ std::vector<double> resultfit (TH1F* hmips, TString gain) {
     double mpv=fitsnr_hmips->GetParameter(1);
     double empv=fitsnr_hmips->GetParError(1);
     double wmpv=fitsnr_hmips->GetParameter(0);
+    double ewmpv=fitsnr_hmips->GetParError(0);
     double chi2ndf=0;
     if(ndf>0) chi2ndf=chisqr/ndf;
 
@@ -107,6 +108,7 @@ std::vector<double> resultfit (TH1F* hmips, TString gain) {
     result.push_back(empv);
     result.push_back(wmpv);
     result.push_back(chi2ndf);
+    result.push_back(ewmpv);
     return result;
 
 }

--- a/SLBperformance/performance/FitHoldscan_TB2021.C
+++ b/SLBperformance/performance/FitHoldscan_TB2021.C
@@ -18,229 +18,243 @@
 #include <fstream>
 #include "TLatex.h"
 
-//#include "../../style/Style.C"
-//#include "../../style/Labels.C"
+// #include "../../style/Style.C"
+// #include "../../style/Labels.C"
 
-Double_t langaufun(Double_t *x, Double_t *par) {
-  //Fit parameters:
-  //par[0]=Width (scale) parameter of Landau density
-  //par[1]=Most Probable (MP, location) parameter of Landau density
-  //par[2]=Total area (integral -inf to inf, normalization constant)
-  //par[3]=Width (sigma) of convoluted Gaussian function
+Double_t langaufun(Double_t *x, Double_t *par)
+{
+  // Fit parameters:
+  // par[0]=Width (scale) parameter of Landau density
+  // par[1]=Most Probable (MP, location) parameter of Landau density
+  // par[2]=Total area (integral -inf to inf, normalization constant)
+  // par[3]=Width (sigma) of convoluted Gaussian function
   //
-  //In the Landau distribution (represented by the CERNLIB approximation), 
-  //the maximum is located at x=-0.22278298 with the location parameter=0.
-  //This shift is corrected within this function, so that the actual
-  //maximum is identical to the MP parameter.
-  
+  // In the Landau distribution (represented by the CERNLIB approximation),
+  // the maximum is located at x=-0.22278298 with the location parameter=0.
+  // This shift is corrected within this function, so that the actual
+  // maximum is identical to the MP parameter.
+
   // Numeric constants
-  Double_t invsq2pi = 0.3989422804014;   // (2 pi)^(-1/2)
-  Double_t mpshift  = -0.22278298;       // Landau maximum location
-  
+  Double_t invsq2pi = 0.3989422804014; // (2 pi)^(-1/2)
+  Double_t mpshift = -0.22278298;      // Landau maximum location
+
   // Control constants
-  Double_t np = 100.0;      // number of convolution steps
-  Double_t sc =   5.0;      // convolution extends to +-sc Gaussian sigmas
-  
+  Double_t np = 100.0; // number of convolution steps
+  Double_t sc = 5.0;   // convolution extends to +-sc Gaussian sigmas
+
   // Variables
   Double_t xx;
   Double_t mpc;
   Double_t fland;
   Double_t sum = 0.0;
-  Double_t xlow,xupp;
+  Double_t xlow, xupp;
   Double_t step;
   Double_t i;
-  
-  
+
   // MP shift correction
-  mpc = par[1] - mpshift * par[0]; 
-  
+  mpc = par[1] - mpshift * par[0];
+
   // Range of convolution integral
   xlow = x[0] - sc * par[3];
   xupp = x[0] + sc * par[3];
-  
-  step = (xupp-xlow) / np;
-  
+
+  step = (xupp - xlow) / np;
+
   // Convolution integral of Landau and Gaussian by sum
-  for(i=1.0; i<=np/2; i++) {
-    xx = xlow + (i-.5) * step;
-    fland = TMath::Landau(xx,mpc,par[0]) / par[0];
-    sum += fland * TMath::Gaus(x[0],xx,par[3]);
-    
-    xx = xupp - (i-.5) * step;
-    fland = TMath::Landau(xx,mpc,par[0]) / par[0];
-    sum += fland * TMath::Gaus(x[0],xx,par[3]);
+  for (i = 1.0; i <= np / 2; i++)
+  {
+    xx = xlow + (i - .5) * step;
+    fland = TMath::Landau(xx, mpc, par[0]) / par[0];
+    sum += fland * TMath::Gaus(x[0], xx, par[3]);
+
+    xx = xupp - (i - .5) * step;
+    fland = TMath::Landau(xx, mpc, par[0]) / par[0];
+    sum += fland * TMath::Gaus(x[0], xx, par[3]);
   }
-  
+
   return (par[2] * step * sum * invsq2pi / par[3]);
 }
 
-
-
-TF1* langaufit(TH1F *his, Double_t *fitrange, Double_t *startvalues, Double_t *parlimitslo, Double_t *parlimitshi, Double_t *fitparams, Double_t *fiterrors, Double_t *ChiSqr, Int_t *NDF)
+TF1 *langaufit(TH1F *his, Double_t *fitrange, Double_t *startvalues, Double_t *parlimitslo, Double_t *parlimitshi, Double_t *fitparams, Double_t *fiterrors, Double_t *ChiSqr, Int_t *NDF)
 {
-   // Once again, here are the Landau * Gaussian parameters:
-   //   par[0]=Width (scale) parameter of Landau density
-   //   par[1]=Most Probable (MP, location) parameter of Landau density
-   //   par[2]=Total area (integral -inf to inf, normalization constant)
-   //   par[3]=Width (sigma) of convoluted Gaussian function
-   //
-   // Variables for langaufit call:
-   //   his             histogram to fit
-   //   fitrange[2]     lo and hi boundaries of fit range
-   //   startvalues[4]  reasonable start values for the fit
-   //   parlimitslo[4]  lower parameter limits
-   //   parlimitshi[4]  upper parameter limits
-   //   fitparams[4]    returns the final fit parameters
-   //   fiterrors[4]    returns the final fit errors
-   //   ChiSqr          returns the chi square
-   //   NDF             returns ndf
+  // Once again, here are the Landau * Gaussian parameters:
+  //   par[0]=Width (scale) parameter of Landau density
+  //   par[1]=Most Probable (MP, location) parameter of Landau density
+  //   par[2]=Total area (integral -inf to inf, normalization constant)
+  //   par[3]=Width (sigma) of convoluted Gaussian function
+  //
+  // Variables for langaufit call:
+  //   his             histogram to fit
+  //   fitrange[2]     lo and hi boundaries of fit range
+  //   startvalues[4]  reasonable start values for the fit
+  //   parlimitslo[4]  lower parameter limits
+  //   parlimitshi[4]  upper parameter limits
+  //   fitparams[4]    returns the final fit parameters
+  //   fiterrors[4]    returns the final fit errors
+  //   ChiSqr          returns the chi square
+  //   NDF             returns ndf
 
-   Int_t i;
-   Char_t FunName[100];
+  Int_t i;
+  Char_t FunName[100];
 
-   sprintf(FunName,"Fitfcn_%s",his->GetName());
+  sprintf(FunName, "Fitfcn_%s", his->GetName());
 
-   TF1 *ffitold = (TF1*)gROOT->GetListOfFunctions()->FindObject(FunName);
-   if (ffitold) delete ffitold;
+  TF1 *ffitold = (TF1 *)gROOT->GetListOfFunctions()->FindObject(FunName);
+  if (ffitold)
+    delete ffitold;
 
-   TF1 *ffit = new TF1(FunName,langaufun,fitrange[0],fitrange[1],4);
-   ffit->SetParameters(startvalues);
-   ffit->SetParNames("Width","MP","Area","GSigma");
-   
-   for (i=0; i<4; i++) {
-      ffit->SetParLimits(i, parlimitslo[i], parlimitshi[i]);
-   }
+  TF1 *ffit = new TF1(FunName, langaufun, fitrange[0], fitrange[1], 4);
+  ffit->SetParameters(startvalues);
+  ffit->SetParNames("Width", "MP", "Area", "GSigma");
 
-   his->Fit(FunName,"RBQM");   // fit within specified range, use ParLimits, quiet, improve fit results (TMINUIT)
+  for (i = 0; i < 4; i++)
+  {
+    ffit->SetParLimits(i, parlimitslo[i], parlimitshi[i]);
+  }
 
-   ffit->GetParameters(fitparams);    // obtain fit parameters
-   for (i=0; i<4; i++) {
-      fiterrors[i] = ffit->GetParError(i);     // obtain fit parameter errors
-   }
-   ChiSqr[0] = ffit->GetChisquare();  // obtain chi^2
-   NDF[0] = ffit->GetNDF();           // obtain ndf
+  his->Fit(FunName, "RBQM"); // fit within specified range, use ParLimits, quiet, improve fit results (TMINUIT)
 
-   return (ffit);              // return fit function
+  ffit->GetParameters(fitparams); // obtain fit parameters
+  for (i = 0; i < 4; i++)
+  {
+    fiterrors[i] = ffit->GetParError(i); // obtain fit parameter errors
+  }
+  ChiSqr[0] = ffit->GetChisquare(); // obtain chi^2
+  NDF[0] = ffit->GetNDF();          // obtain ndf
 
+  return (ffit); // return fit function
 }
 
+void FitHoldscan_TB2021(TString rootfile = "MIPs_050031", int chip0 = 12)
+{
 
-void FitHoldscan_TB2021(TString rootfile="MIPs_050031", int chip0=12) {
-
-  TFile* outFile = new TFile(TString("HoldScans_Run_") + rootfile(5,11) + ".root", "RECREATE");
+  TFile *outFile = new TFile(TString("HoldScans_Run_") + rootfile(5, 11) + ".root", "RECREATE");
   outFile->mkdir("LangauFits");
   outFile->mkdir("HoldScans");
-  
-  int nSLB=15;
-  int holdv[10]={30,40,50,60,70,80,100,140};
+
+  int nSLB = 15;
+  int holdv[10] = {30, 40, 50, 60, 70, 80, 100, 140};
 
   double holdsMPV[15][4][8];
-  
-  for(int ihold=0; ihold<8;ihold++) {
-    
-    TFile *_file0 = TFile::Open(TString::Format("%s_hold%i.root",rootfile.Data(),holdv[ihold]));
-    for(int ilayer=0; ilayer<nSLB; ilayer++) {
 
-      for(int ichip=chip0; ichip<chip0+4; ichip++) {
-	std::cout << "Processing hold: " << holdv[ihold] << " layer: " << ilayer << " chip: " << ichip << std::endl;
-	TH1F* htemp=(TH1F*)_file0->Get(TString::Format("layer_%i/charge_layer%i_chip%i",ilayer,ilayer,ichip));
-	
-	Double_t fr[2];
-	Double_t sv[4], pllo[4], plhi[4], fp[4], fpe[4];
-	// Width MP Area GSigma
-	pllo[0]=1.0; pllo[1]=20; pllo[2]=100.0; pllo[3]=1;
-	plhi[0]=100.0; plhi[1]=100.0; plhi[2]=100000000.0; plhi[3]=30.0;
-	sv[0]=3.0; sv[1]=60.0; sv[2]=10000.0; sv[3]=8.0;
-	Double_t chisqr;
-	Int_t    ndf;
-	
-	
-	if(htemp != nullptr && htemp->GetEntries()>100){
-	  fr[0]=0;
-	  fr[1]=150+100*ilayer;
-	  TF1 *fitsnr_temp=langaufit(htemp,fr,sv,pllo,plhi,fp,fpe,&chisqr,&ndf);
+  for (int ihold = 0; ihold < 8; ihold++)
+  {
 
-	  outFile->cd("LangauFits");
-	  htemp->SetTitle(htemp->GetTitle() + TString::Format("_hold%i",holdv[ihold]) + ";MP;Entries");
-	  htemp->SetName(htemp->GetTitle() + TString::Format("_hold%i",holdv[ihold]));
-	  htemp->Write();
-	  
-	  double mpv=fitsnr_temp->GetParameter(1);
-	  double empv=fitsnr_temp->GetParError(1);
-	  double wmpv=fitsnr_temp->GetParameter(0);
-	  double chi2ndf=0;
+    TFile *_file0 = TFile::Open(TString::Format("%s_hold%i.root", rootfile.Data(), holdv[ihold]));
+    for (int ilayer = 0; ilayer < nSLB; ilayer++)
+    {
 
-	  holdsMPV[ilayer][ichip%4][ihold] = mpv;
-	}
-	else {
-	  holdsMPV[ilayer][ichip%4][ihold] = -1;
-	}
-	
+      for (int ichip = chip0; ichip < chip0 + 4; ichip++)
+      {
+        std::cout << "Processing hold: " << holdv[ihold] << " layer: " << ilayer << " chip: " << ichip << std::endl;
+        TH1F *htemp = (TH1F *)_file0->Get(TString::Format("layer_%i/charge_layer%i_chip%i", ilayer, ilayer, ichip));
+
+        Double_t fr[2];
+        Double_t sv[4], pllo[4], plhi[4], fp[4], fpe[4];
+        // Width MP Area GSigma
+        pllo[0] = 1.0;
+        pllo[1] = 20;
+        pllo[2] = 100.0;
+        pllo[3] = 1;
+        plhi[0] = 100.0;
+        plhi[1] = 100.0;
+        plhi[2] = 100000000.0;
+        plhi[3] = 30.0;
+        sv[0] = 3.0;
+        sv[1] = 60.0;
+        sv[2] = 10000.0;
+        sv[3] = 8.0;
+        Double_t chisqr;
+        Int_t ndf;
+
+        if (htemp != nullptr && htemp->GetEntries() > 100)
+        {
+          fr[0] = 0;
+          fr[1] = 150 + 100 * ilayer;
+          TF1 *fitsnr_temp = langaufit(htemp, fr, sv, pllo, plhi, fp, fpe, &chisqr, &ndf);
+
+          outFile->cd("LangauFits");
+          htemp->SetTitle(htemp->GetTitle() + TString::Format("_hold%i", holdv[ihold]) + ";MP;Entries");
+          htemp->SetName(htemp->GetTitle() + TString::Format("_hold%i", holdv[ihold]));
+          htemp->Write();
+
+          double mpv = fitsnr_temp->GetParameter(1);
+          double empv = fitsnr_temp->GetParError(1);
+          double wmpv = fitsnr_temp->GetParameter(0);
+          double chi2ndf = 0;
+
+          holdsMPV[ilayer][ichip % 4][ihold] = mpv;
+        }
+        else
+        {
+          holdsMPV[ilayer][ichip % 4][ihold] = -1;
+        }
       }
-
     }
 
     _file0->Close();
-
   }
 
   outFile->cd("HoldScans");
-  
+
   std::ofstream output;
   output.open("FittedHoldValues.txt", ios_base::trunc);
   output << "Layer \t Chip \t MaxHold" << std::endl;
-  
-  double holdsDoubles[8] = {30, 40, 50 ,60 ,70 ,80 ,100, 140};
 
-  for(int iLayer = 0; iLayer < 15; iLayer++) {
+  double holdsDoubles[8] = {30, 40, 50, 60, 70, 80, 100, 140};
 
-    TCanvas* layerCanvas = new TCanvas(TString::Format("HoldsVsMPV_Layer%i",iLayer));
-    TLegend* legend = new TLegend(0.7,0.7,0.9,0.9);
-    
-    for(int iChip = 0; iChip < 4; iChip++) {
+  for (int iLayer = 0; iLayer < 15; iLayer++)
+  {
 
-      double* y = holdsMPV[iLayer][iChip]; 
-      
-      TGraph* graph = new TGraph();
+    TCanvas *layerCanvas = new TCanvas(TString::Format("HoldsVsMPV_Layer%i", iLayer));
+    TLegend *legend = new TLegend(0.7, 0.7, 0.9, 0.9);
+
+    for (int iChip = 0; iChip < 4; iChip++)
+    {
+
+      double *y = holdsMPV[iLayer][iChip];
+
+      TGraph *graph = new TGraph();
 
       int n = 0;
-      for(int iHold = 0; iHold < 8; iHold++) {
+      for (int iHold = 0; iHold < 8; iHold++)
+      {
 
-	if(y[iHold] > 0) {
-	  graph->Set(n+1);
-	  graph->SetPoint(n,holdsDoubles[iHold],y[iHold]);
-	  n++;	  
-	}
+        if (y[iHold] > 0)
+        {
+          graph->Set(n + 1);
+          graph->SetPoint(n, holdsDoubles[iHold], y[iHold]);
+          n++;
+        }
       }
-      
-      graph->SetMarkerColor(iChip+1);
-      graph->SetTitle(TString::Format("MPVVsHold_Layer%i;Hold;MPV",iLayer));
-      graph->GetYaxis()->SetRangeUser(0,150);
+
+      graph->SetMarkerColor(iChip + 1);
+      graph->SetTitle(TString::Format("MPVVsHold_Layer%i;Hold;MPV", iLayer));
+      graph->GetYaxis()->SetRangeUser(0, 150);
 
       graph->Fit("pol2", "Q");
-      
-      TF1* fitfunc = (TF1*)graph->GetListOfFunctions()->FindObject("pol2");
-      if(fitfunc != nullptr) {
-	output << iLayer << "\t" << chip0+iChip << "\t" << fitfunc->GetMaximumX(0,140) << std::endl;
-	fitfunc->SetLineColor(iChip+1);
-      }
-      
-      legend->AddEntry(graph,TString::Format("Chip%i",chip0+iChip));
-    
-      TString drawOption = "AP*";  
-      if(iChip != 0) drawOption = "P*SAME";
-      
-      graph->Draw(drawOption);
 
+      TF1 *fitfunc = (TF1 *)graph->GetListOfFunctions()->FindObject("pol2");
+      if (fitfunc != nullptr)
+      {
+        output << iLayer << "\t" << chip0 + iChip << "\t" << fitfunc->GetMaximumX(0, 140) << std::endl;
+        fitfunc->SetLineColor(iChip + 1);
+      }
+
+      legend->AddEntry(graph, TString::Format("Chip%i", chip0 + iChip));
+
+      TString drawOption = "AP*";
+      if (iChip != 0)
+        drawOption = "P*SAME";
+
+      graph->Draw(drawOption);
     }
 
     legend->Draw();
     layerCanvas->Write();
     delete layerCanvas;
   }
-  
+
   output.close();
   outFile->Close();
-  
 }
-				

--- a/SLBperformance/performance/compare_MIP.C
+++ b/SLBperformance/performance/compare_MIP.C
@@ -10,26 +10,28 @@
 #include <iostream>
 #include <fstream>
 
-//#include "../../style/Style.C"
-//#include "../../style/Labels.C"
+// #include "../../style/Style.C"
+// #include "../../style/Labels.C"
 
 using namespace std;
 
-void compare_MIP(){//TString filename, int slabadd){
-  
+void compare_MIP()
+{ // TString filename, int slabadd){
 
   TString filename = "plots/SLB_3_Run_ILC_slab14_HV100_12192019_15h07min_Ascii.root";
 
   TFile *_file_1 = TFile::Open(filename);
 
   TH1F *mip_1[16][64];
-  for(int iasic=0; iasic<16; iasic++) {
-    for(int ichn=0; ichn<64; ichn++) {
-      
-      if(_file_1->Get(TString::Format("histograms_mip/mip_chip%i_chn%i",iasic,ichn)))
-	mip_1[iasic][ichn]=(TH1F*)_file_1->Get(TString::Format("histograms_mip/mip_chip%i_chn%i",iasic,ichn));
-      else mip_1[iasic][ichn]=NULL;
+  for (int iasic = 0; iasic < 16; iasic++)
+  {
+    for (int ichn = 0; ichn < 64; ichn++)
+    {
 
+      if (_file_1->Get(TString::Format("histograms_mip/mip_chip%i_chn%i", iasic, ichn)))
+        mip_1[iasic][ichn] = (TH1F *)_file_1->Get(TString::Format("histograms_mip/mip_chip%i_chn%i", iasic, ichn));
+      else
+        mip_1[iasic][ichn] = NULL;
     }
   }
 
@@ -38,58 +40,58 @@ void compare_MIP(){//TString filename, int slabadd){
   TFile *_file_2 = TFile::Open(filename);
 
   TH1F *mip_2[16][64];
-  for(int iasic=0; iasic<16; iasic++) {
-    for(int ichn=0; ichn<64; ichn++) {
+  for (int iasic = 0; iasic < 16; iasic++)
+  {
+    for (int ichn = 0; ichn < 64; ichn++)
+    {
 
-      if(_file_2->Get(TString::Format("histograms_mip/mip_chip%i_chn%i",iasic,ichn)))
-	mip_2[iasic][ichn]=(TH1F*)_file_2->Get(TString::Format("histograms_mip/mip_chip%i_chn%i",iasic,ichn));
-      else mip_2[iasic][ichn]=NULL;
-
+      if (_file_2->Get(TString::Format("histograms_mip/mip_chip%i_chn%i", iasic, ichn)))
+        mip_2[iasic][ichn] = (TH1F *)_file_2->Get(TString::Format("histograms_mip/mip_chip%i_chn%i", iasic, ichn));
+      else
+        mip_2[iasic][ichn] = NULL;
     }
   }
-      
 
   TCanvas *canvas_asic[16];
 
-  for(int iasic=5; iasic<6; iasic++) {
-    
-    canvas_asic[iasic]= new TCanvas(TString::Format("asic_%i",iasic),TString::Format("asic_%i",iasic),1600,1000);
-    canvas_asic[iasic]->Divide(8,8);
-    
-    TLegend *leg2 = new TLegend(0.6,0.7,0.9,0.9);
-    bool write_leg1=false;
-    bool write_leg2=false;
+  for (int iasic = 5; iasic < 6; iasic++)
+  {
 
-    for(int ichn=0; ichn<64; ichn++) {
-      if(mip_1[iasic][ichn]==NULL) continue;
+    canvas_asic[iasic] = new TCanvas(TString::Format("asic_%i", iasic), TString::Format("asic_%i", iasic), 1600, 1000);
+    canvas_asic[iasic]->Divide(8, 8);
 
-      canvas_asic[iasic]->cd(1+ichn);
+    TLegend *leg2 = new TLegend(0.6, 0.7, 0.9, 0.9);
+    bool write_leg1 = false;
+    bool write_leg2 = false;
+
+    for (int ichn = 0; ichn < 64; ichn++)
+    {
+      if (mip_1[iasic][ichn] == NULL)
+        continue;
+
+      canvas_asic[iasic]->cd(1 + ichn);
       mip_1[iasic][ichn]->GetXaxis()->SetTitle("DAC");
       mip_1[iasic][ichn]->GetYaxis()->SetTitle("Nhits");
       mip_1[iasic][ichn]->SetLineColor(1);
-      mip_1[iasic][ichn]->SetTitle(TString::Format("ASIC %i",iasic));
-      if(write_leg1==false) {
-	leg2->AddEntry(mip_1[iasic][ichn],"HV=100V","l");
-	write_leg1=true;
+      mip_1[iasic][ichn]->SetTitle(TString::Format("ASIC %i", iasic));
+      if (write_leg1 == false)
+      {
+        leg2->AddEntry(mip_1[iasic][ichn], "HV=100V", "l");
+        write_leg1 = true;
       }
       mip_1[iasic][ichn]->DrawNormalized("histo");
 
-      if(mip_2[iasic][ichn]!=NULL) {
-	mip_2[iasic][ichn]->SetLineColor(2);
-	mip_2[iasic][ichn]->DrawNormalized("histosame");
-	if(write_leg2==false) {
-	  leg2->AddEntry(mip_2[iasic][ichn],"HV=180V","l");
-	  write_leg2=true;
-	}
+      if (mip_2[iasic][ichn] != NULL)
+      {
+        mip_2[iasic][ichn]->SetLineColor(2);
+        mip_2[iasic][ichn]->DrawNormalized("histosame");
+        if (write_leg2 == false)
+        {
+          leg2->AddEntry(mip_2[iasic][ichn], "HV=180V", "l");
+          write_leg2 = true;
+        }
       }
       leg2->Draw();
     }
   }
-  
-  
 }
-
-
-
-
-

--- a/eventbuilding/build_events.py
+++ b/eventbuilding/build_events.py
@@ -392,11 +392,11 @@ class BuildEvents:
             if branch_name == "hit_energy":
                 mip = self.ecal_config.mip_map[event.hit_slab, event.hit_chip, event.hit_chan]
                 pedestal = self.ecal_config.pedestal_map[event.hit_slab, event.hit_chip, event.hit_chan, event.hit_sca]
-                arr = (event.hit_adc_high - pedestal) + mip
+                arr = (event.hit_adc_high - pedestal) / mip
             elif branch_name == "hit_energy_lg":
                 mip = self.ecal_config.mip_lg_map[event.hit_slab, event.hit_chip, event.hit_chan]
                 pedestal = self.ecal_config.pedestal_lg_map[event.hit_slab, event.hit_chip, event.hit_chan, event.hit_sca]
-                arr = (event.hit_adc_low - pedestal) + mip
+                arr = (event.hit_adc_low - pedestal) / mip
             elif branch_name == "hit_isCommissioned":
                 arr = self.ecal_config.is_commissioned_map[event.hit_slab, event.hit_chip, event.hit_chan, event.hit_sca]
             elif branch_name == "hit_isMasked":

--- a/eventbuilding/ecal_config.py
+++ b/eventbuilding/ecal_config.py
@@ -277,7 +277,9 @@ class EcalConfig:
         if np.any(has_bad_mip):
             mip_malfunctioning_chip = float(self._commissioning_config["mip_malfunctioning_chip"])
             channel_is_used_for_average = mip_map >= mip_cutoff
-            per_chip_average = channel_is_used_for_average.mean(axis=-1)
+            channel_is_used_for_average_with_mpv = np.where(channel_is_used_for_average, mip_map, 0)
+            np.seterr(invalid='ignore')
+            per_chip_average = np.true_divide(channel_is_used_for_average_with_mpv.sum(2),(channel_is_used_for_average_with_mpv!=0).sum(2))
             per_chip_average[per_chip_average == 0] = mip_malfunctioning_chip
             mip_average_on_chip = np.empty_like(mip_map)
             mip_average_on_chip[:] = np.expand_dims(

--- a/macros/Styles.hh
+++ b/macros/Styles.hh
@@ -1,0 +1,27 @@
+#include <iostream>
+#include <vector>
+
+using std::cout; using std::endl;
+using std::vector;
+
+template <class P1>
+void StylePad(P1 *pad, Float_t t, Float_t b, Float_t r, Float_t l)
+{
+  pad->SetGrid(1,1);
+  if(t) pad->SetTopMargin(t);
+  if(b) pad->SetBottomMargin(b);
+  if(r) pad->SetRightMargin(r);
+  if(l) pad->SetLeftMargin(l);
+  pad->Draw();
+  pad->cd();
+
+}
+
+template <class H>
+void StyleHist(H *h, Color_t col)
+{
+  h->SetLineWidth(3);
+  h->SetLineColor(col);
+  h->SetFillStyle(3002);
+  h->SetFillColor(col);
+}

--- a/macros/Styles.hh
+++ b/macros/Styles.hh
@@ -7,7 +7,7 @@ using std::vector;
 template <class P1>
 void StylePad(P1 *pad, Float_t t, Float_t b, Float_t r, Float_t l)
 {
-  pad->SetGrid(1,1);
+  // pad->SetGrid(1,1);
   if(t) pad->SetTopMargin(t);
   if(b) pad->SetBottomMargin(b);
   if(r) pad->SetRightMargin(r);

--- a/macros/drawMIPs.C
+++ b/macros/drawMIPs.C
@@ -54,7 +54,31 @@ void drawMIPs()
 
   TFile *file_MIPSummary = new TFile("../mip_calib/MIPSummary_pedestalsubmode1_raw_siwecal_90021to90070_highgain.root", "READ");
 
-  // TCanvas *c_MIPSummary[15];
+  TCanvas * mip_all = new TCanvas("mip_all","mip_all",800,800);
+  mip_all->SetLeftMargin(0.12);
+  mip_all->SetRightMargin(0.15);
+  TH2F * h_mip_all = (TH2F*) file_MIPSummary->Get("mpv_all");
+  h_mip_all->SetTitle("");
+  h_mip_all->GetXaxis()->SetTitle("Layer #times 20 + Chip");
+  h_mip_all->GetYaxis()->SetTitle("Channel");
+  h_mip_all->GetZaxis()->SetTitle("MIP value [ADC]");
+  h_mip_all->GetZaxis()->SetTitleOffset(1.2);
+  h_mip_all->GetZaxis()->SetRangeUser(0, 50);
+  h_mip_all->Draw("colz");
+
+  TCanvas * width_all = new TCanvas("width_all","width_all",800,800);
+  width_all->SetLeftMargin(0.12);
+  width_all->SetRightMargin(0.15);
+  TH2F * h_width_all = (TH2F*) file_MIPSummary->Get("width_all");
+  h_width_all->SetTitle("");
+  h_width_all->GetXaxis()->SetTitle("Layer #times 20 + Chip");
+  h_width_all->GetYaxis()->SetTitle("Channel");
+  h_width_all->GetZaxis()->SetTitle("MIP width [ADC]");
+  h_width_all->GetZaxis()->SetTitleOffset(1.2);
+  h_width_all->GetZaxis()->SetRangeUser(0, 10);
+  h_width_all->Draw("colz");
+
+
 
   Bool_t drawIt = true;
   TCanvas *c_MIPSummary_layer7_0 = new TCanvas(TString::Format("MIPSummary_layer%i_0", 7), TString::Format("MIPSummary_layer%i_0", 7), 800, 800);
@@ -84,18 +108,31 @@ void drawMIPs()
 
               if(i==7 && drawIt){
                 c_MIPSummary_layer7_0->cd();
+                c_MIPSummary_layer7_0->DrawFrame(0,0,1,1);
                 TH1F* h_0 = (TH1F*)h->Clone();
+                c_MIPSummary_layer7_0->SetGrid();
+                c_MIPSummary_layer7_0->SetLeftMargin(0.15);
                 std::vector<double> result = resultfit(h_0,"high");
+                double MIP     = result.at(0);
+                double MIP_err = result.at(1);
+                double MIP_w   = result.at(2);
+                double chi2ndf = result.at(3);
+                double MIP_w_err = result.at(4);
 
+                h_0->GetXaxis()->SetRangeUser(0, 100);
                 h_0->Draw();
 
                 TLatex latex;
-                const char *longstring = "K_{S}... K^{*0}... #frac{2s}{#pi#alpha^{2}} #frac{d#sigma}{dcos#theta} (e^{+}e^{-} #rightarrow f#bar{f} ) = #left| #frac{1}{1 - #Delta#alpha} #right|^{2} (1+cos^{2}#theta)";
                 latex.SetTextSize(0.025);
                 latex.SetTextAlign(13);  //align at top
-                latex.DrawLatex(.2,.9,"K_{S}");
-                latex.DrawLatex(.3,.9,"K^{*0}");
-                latex.DrawLatex(.2,.8,longstring);
+                // latex.DrawLatex(65,5000,TString::Format("MIP = %.2f #pm %.2f\\\\
+                // MIP width = %.2f #pm %.2f\\\\
+                // #chi^{2}/ndf = %.2f",
+                // MIP, MIP_err, MIP_w, MIP_w_err, chi2ndf));
+
+                latex.DrawLatex(60,4700,TString::Format("MIP = %.2f #pm %.2f", MIP, MIP_err));
+                latex.DrawLatex(60,4500,TString::Format("MIP width = %.2f #pm %.2f", MIP_w, MIP_w_err));
+                latex.DrawLatex(60,4300,TString::Format("#chi^{2}/ndf = %.2f", chi2ndf));
                 c_MIPSummary_layer7_0->Draw();
 
 
@@ -110,7 +147,7 @@ void drawMIPs()
 
     c_MIPSummary->cd();
     // c_MIPSummary->Draw();
-    c_MIPSummary->SaveAs(TString::Format("plots/MIPs/MIPSummary_layer%i.pdf", i));
+    // c_MIPSummary->SaveAs(TString::Format("plots/MIPs/MIPSummary_layer%i.pdf", i));
   }
 
 }

--- a/macros/drawMIPs.C
+++ b/macros/drawMIPs.C
@@ -1,0 +1,117 @@
+#include "TFile.h"
+#include "TCanvas.h"
+#include "TPaveStats.h"
+#include "TH1.h"
+#include "TROOT.h"
+#include "TRint.h"
+#include "TStyle.h"
+#include "TLegend.h"
+#include "TString.h"
+#include "TMath.h"
+#include <iostream>
+#include <fstream>
+#include "TF1.h"
+#include "Styles.hh"
+#include "../SLBperformance/TBchecks/analysis.h"
+
+// #include "../SLBco/conf_struct.h"
+
+// #include "../../style/Style.C"
+// #include "../../style/Labels.C"
+
+using namespace std;
+
+int nslabs = 15;
+// int nchips = 16;
+int nchannels = 64;
+int nchannels_fit = 6;
+
+Float_t charge_low[16][64];  // daughter, slab, asic, chn, DAC
+Float_t charge_high[16][64]; // daughter, slab, asic, chn, DAC
+
+void drawMIPs()
+{
+
+  //  TCanvas *Tlva = new TCanvas("Tlva","Tlva",500,500);
+  //  Tlva->SetGrid();
+  //  Tlva->DrawFrame(0,0,1,1);
+  //  const char *longstring = "K_{S}... K^{*0}... #frac{2s}{#pi#alpha^{2}} #frac{d#sigma}{dcos#theta} (e^{+}e^{-} #rightarrow f#bar{f} ) = #left| #frac{1}{1 - #Delta#alpha} #right|^{2} (1+cos^{2}#theta)";
+ 
+  //  TLatex latex;
+  //  latex.SetTextSize(0.025);
+  //  latex.SetTextAlign(13);  //align at top
+  //  latex.DrawLatex(.2,.9,"K_{S}");
+  //  latex.DrawLatex(.3,.9,"K^{*0}");
+  //  latex.DrawLatex(.2,.8,longstring);
+ 
+  //  Tlva->Draw();
+
+
+
+
+
+
+
+  TFile *file_MIPSummary = new TFile("../mip_calib/MIPSummary_pedestalsubmode1_raw_siwecal_90021to90070_highgain.root", "READ");
+
+  // TCanvas *c_MIPSummary[15];
+
+  Bool_t drawIt = true;
+  TCanvas *c_MIPSummary_layer7_0 = new TCanvas(TString::Format("MIPSummary_layer%i_0", 7), TString::Format("MIPSummary_layer%i_0", 7), 800, 800);
+  gStyle->SetOptStat(1111);
+  gStyle->SetOptFit(111);
+
+  for (int i = 0; i < nslabs; i++)
+  {
+    TCanvas * c_MIPSummary = (TCanvas*) file_MIPSummary->Get(TString::Format("MIPSummary_layer%i", i));
+    TList *primitives = c_MIPSummary->GetListOfPrimitives();
+    TIter next(primitives);
+    TObject* obj;
+    while ((obj = next())) {
+        TPad *pad = (TPad*)obj;
+        // StylePad(pad,0,0.15,0,0.17);
+        pad->SetLeftMargin(0.15);
+        pad->SetGrid(1,1);
+
+        TList *primitives2 = ((TPad*)obj)->GetListOfPrimitives();
+        TIter next2(primitives2);
+        TObject* obj2;
+        while ((obj2 = next2())) {
+          if (obj2->InheritsFrom("TH1")) {
+              TH1F* h = (TH1F*)obj2;
+              h->GetXaxis()->SetTitle("Charge [ADC]");
+              h->GetYaxis()->SetTitle("Entries");
+
+              if(i==7 && drawIt){
+                c_MIPSummary_layer7_0->cd();
+                TH1F* h_0 = (TH1F*)h->Clone();
+                std::vector<double> result = resultfit(h_0,"high");
+
+                h_0->Draw();
+
+                TLatex latex;
+                const char *longstring = "K_{S}... K^{*0}... #frac{2s}{#pi#alpha^{2}} #frac{d#sigma}{dcos#theta} (e^{+}e^{-} #rightarrow f#bar{f} ) = #left| #frac{1}{1 - #Delta#alpha} #right|^{2} (1+cos^{2}#theta)";
+                latex.SetTextSize(0.025);
+                latex.SetTextAlign(13);  //align at top
+                latex.DrawLatex(.2,.9,"K_{S}");
+                latex.DrawLatex(.3,.9,"K^{*0}");
+                latex.DrawLatex(.2,.8,longstring);
+                c_MIPSummary_layer7_0->Draw();
+
+
+                drawIt = false;
+              }
+
+              // h->Draw();
+          }
+        }
+
+    }
+
+    c_MIPSummary->cd();
+    // c_MIPSummary->Draw();
+    c_MIPSummary->SaveAs(TString::Format("plots/MIPs/MIPSummary_layer%i.pdf", i));
+  }
+
+}
+

--- a/macros/drawMIPs.C
+++ b/macros/drawMIPs.C
@@ -31,27 +31,6 @@ Float_t charge_high[16][64]; // daughter, slab, asic, chn, DAC
 
 void drawMIPs()
 {
-
-  //  TCanvas *Tlva = new TCanvas("Tlva","Tlva",500,500);
-  //  Tlva->SetGrid();
-  //  Tlva->DrawFrame(0,0,1,1);
-  //  const char *longstring = "K_{S}... K^{*0}... #frac{2s}{#pi#alpha^{2}} #frac{d#sigma}{dcos#theta} (e^{+}e^{-} #rightarrow f#bar{f} ) = #left| #frac{1}{1 - #Delta#alpha} #right|^{2} (1+cos^{2}#theta)";
- 
-  //  TLatex latex;
-  //  latex.SetTextSize(0.025);
-  //  latex.SetTextAlign(13);  //align at top
-  //  latex.DrawLatex(.2,.9,"K_{S}");
-  //  latex.DrawLatex(.3,.9,"K^{*0}");
-  //  latex.DrawLatex(.2,.8,longstring);
- 
-  //  Tlva->Draw();
-
-
-
-
-
-
-
   TFile *file_MIPSummary = new TFile("../mip_calib/MIPSummary_pedestalsubmode1_raw_siwecal_90021to90070_highgain.root", "READ");
 
   TCanvas * mip_all = new TCanvas("mip_all","mip_all",800,800);

--- a/macros/drawScurve.C
+++ b/macros/drawScurve.C
@@ -1,0 +1,182 @@
+#include "TFile.h"
+#include "TCanvas.h"
+#include "TPaveStats.h"
+#include "TH1.h"
+#include "TROOT.h"
+#include "TRint.h"
+#include "TStyle.h"
+#include "TLegend.h"
+#include "TString.h"
+#include "TMath.h"
+#include <iostream>
+#include <fstream>
+#include "TF1.h"
+#include "Styles.hh"
+// #include "../SLBperformance/TBchecks/analysis.h"
+#include "../SLBcommissioning/conf_struct.h"
+
+using namespace std;
+
+const Int_t NSLABS = 15;
+const Int_t NCHIPS = 16;
+const Int_t NCHANNELS = 64;
+
+
+float FirstDrop(TGraphErrors *gr)
+{
+
+  int imax = TMath::LocMax(gr->GetN(), gr->GetY());
+  Double_t xmax, ymax;
+  Double_t tmpy;
+  gr->GetPoint(imax, xmax, ymax);
+  tmpy = ymax;
+
+  for (int i = imax; i < gr->GetN(); i++)
+  {
+    gr->GetPoint(i, xmax, ymax);
+    if (ymax < 0.9 * tmpy)
+      return xmax;
+  }
+
+  return 0;
+}
+
+float FirstZero(TGraphErrors *gr)
+{
+
+  int imax = TMath::LocMax(gr->GetN(), gr->GetY());
+  Double_t xmax, ymax;
+  gr->GetPoint(imax, xmax, ymax);
+
+  // if(imax==0) return 0;
+
+  for (int i = imax; i < gr->GetN(); i++)
+  {
+    gr->GetPoint(i, xmax, ymax);
+    if (ymax < 0.05)
+      return xmax;
+  }
+
+  return 0;
+}
+
+TF1 *FitScurve(TGraphErrors *gr, float xmin_ = 200, float xmax_ = 350, float x0 = 200)
+{
+
+  double par1 = 0, par2 = 0, par3 = 0;
+
+  int imax = TMath::LocMax(gr->GetN(), gr->GetY());
+  int n = gr->GetN();
+  double *x = gr->GetX();
+  double *y = gr->GetY();
+
+  if (n == 0 || y[imax] == 0)
+    return NULL;
+
+  double xmin = FirstZero(gr) - 15; // max(x[imax],x[n/3])-5;
+  double xmax = FirstZero(gr) + 15;
+  double ymax = y[imax];
+
+  TF1 *fit1 = new TF1("fit1", "[0]*TMath::Erfc((x-[1])/(sqrt(2)*[2]))", xmin, xmax);
+
+  // fit1->SetParLimits(0, ymax * 0.1, ymax * 10);
+  fit1->SetParLimits(0, 0, ymax * 1.5);
+  fit1->SetParLimits(1, xmin_, xmax_);
+
+  fit1->SetParameter(0, ymax);
+  // fit1->SetParameter(1,250);
+  fit1->SetParameter(2, 3);
+  gr->Fit("fit1", "QR0");
+
+  par1 = fit1->GetParameter(0);
+  par2 = fit1->GetParameter(1);
+  par3 = fit1->GetParameter(2);
+
+  xmin = max(par2 - 8 * par3, x[n / 3]);
+  xmax = par2 + 20 * par3;
+  TF1 *fit2 = new TF1("fit2", "[0]*TMath::Erfc((x-[1])/[2]+[3])", xmin, xmax);
+
+  fit2->SetParLimits(0, par1 * 0.3, par1 + par1 * 0.5);
+  fit2->SetParLimits(1, xmin_, xmax_);
+  fit2->SetParLimits(2, 1.5, 10);
+
+  fit2->SetParameter(0, par1);
+  fit2->SetParameter(1, par2);
+  fit2->SetParameter(2, par3);
+  gr->Fit("fit2", "QR0");
+
+  return fit2;
+}
+
+void drawScurve()
+{
+  read_configuration_file("../SLBcommissioning/thresholds/Run_Settings_090185.txt", false);
+
+  TFile *file_scurve = new TFile("../SLBcommissioning/thresholds/histos/scurves_06132022_1MIPinjection_chn0to7.root", "READ");
+
+// detector.slab[0][islab].asu[0].skiroc[ichip].mask[ichn] == 0
+
+  TCanvas * c_scurve_sample = new TCanvas("c_scurve_sample","c_scurve_sample",800,800);
+  c_scurve_sample->SetLeftMargin(0.12);
+  c_scurve_sample->SetRightMargin(0.07);
+  c_scurve_sample->SetGrid();
+
+  TMultiGraph *mg = new TMultiGraph();
+  TF1 *fit_scurve_sample[8];
+
+  Color_t color[8] = {kRed, kBlue, kGreen, kMagenta, kCyan, kOrange, kYellow, kBlack};
+  TString legend[8];
+
+  for(int ichn=0; ichn < 8; ichn++){
+    TGraphErrors * h_scurve_sample = (TGraphErrors*) file_scurve->Get(Form("scurve_slbAdd0_chip12_chn%i", ichn));
+    fit_scurve_sample[ichn] = FitScurve(h_scurve_sample);
+    h_scurve_sample->SetMarkerColor(color[ichn]);
+    h_scurve_sample->SetLineColor(color[ichn]);
+    h_scurve_sample->SetMarkerStyle(20+ichn);
+    h_scurve_sample->SetMarkerSize(1.5);
+    // h_scurve_sample->SetLineWidth(2);
+    fit_scurve_sample[ichn]->SetLineColor(color[ichn]);
+    fit_scurve_sample[ichn]->SetLineWidth(2);
+
+    legend[ichn] = Form("Channel %i", ichn);
+
+    mg->Add(h_scurve_sample,"lp");
+  }
+  mg->SetTitle(";DAC;N Hits");
+  gStyle->SetPalette(55);
+  mg->Draw("a");
+  for(int ichn=0; ichn < 8; ichn++){
+    fit_scurve_sample[ichn]->Draw("same");
+  }
+
+  TLegend *leg = new TLegend(0.16,0.14,0.43,0.37);
+  leg->SetHeader("#bf{Channels}");
+  for(int ichn=0; ichn < 8; ichn++){
+    leg->AddEntry(fit_scurve_sample[ichn],legend[ichn],"l");
+  }
+  leg->Draw();
+
+
+  // TGraphErrors * h_scurve_sample = (TGraphErrors*) file_scurve->Get("scurve_slbAdd0_chip12_chn0");
+  // TF1 *fit_scurve_sample = FitScurve(h_scurve_sample);
+
+  // h_scurve_sample->SetTitle(";DAC;N Hits");
+  // h_scurve_sample->Draw("");
+
+  // TF1 *scurvefit[15][16][64];
+
+  // for(int islab = 0; islab < NSLABS; islab++){
+  //   for(int ichip = 0; ichip < NCHIPS; ichip++){
+  //     for(int ichn = 0; ichn < NCHANNELS; ichn++){
+
+
+
+  //     }
+
+  //   }
+
+  // }
+
+
+}
+

--- a/mapping/createmapping.C
+++ b/mapping/createmapping.C
@@ -65,8 +65,8 @@ void createmapping(TString run = "PedestalMIP_3GeVMIPscan", TString gain = "low"
         TH2F *map_chip = new TH2F("map_chip_" + str_name, "map; chip; chn", 16, -0.5, 15.5, 1, -0.5, 63.5);
         TH2F *mapxy = new TH2F("mapxy_" + str_name, "map-xy; x [mm]; y [mm]", 32, -90, 90, 32, -90, 90);
         TH2F *mapIJ = new TH2F("mapIJ_" + str_name, "map-IJ; I; J", 32, -0.5, 31.5, 32, -0.5, 31.5);
-        TH2F *mapxy_chip = new TH2F("mapxy_chip_" + str_name, "map-xy; x; y", 32, -90, 90, 32, -90, 90);
-        TH2F *mapxy_chip_display = new TH2F("mapxy_chip_display_" + str_name, "map-xy; x; y", 4, -90, 90, 4, -90, 90);
+        TH2F *mapxy_chip = new TH2F("mapxy_chip_" + str_name, "map-xy; x [mm]; y [mm]", 32, -90, 90, 32, -90, 90);
+        TH2F *mapxy_chip_display = new TH2F("mapxy_chip_display_" + str_name, "map-xy; x [mm]; y [mm]", 4, -90, 90, 4, -90, 90);
         TH2F *mapIJ_chip = new TH2F("mapIJ_chip_" + str_name, "map-IJ; I; J", 32, -0.5, 31.5, 32, -0.5, 31.5);
 
         for (int i = 0; i < 16; i++)
@@ -116,8 +116,8 @@ void createmapping(TString run = "PedestalMIP_3GeVMIPscan", TString gain = "low"
         pad1->SetGrid(0,0);
         mapxy_chip->SetTitle("");
         mapxy_chip->Draw("col");
-        mapxy_chip_display->Draw("textsame");
-        // mapxy->Draw("textsame");
+        // mapxy_chip_display->Draw("textsame");
+        mapxy->Draw("textsame");
 
         /*
         TCanvas *canvas2 = new TCanvas(TString::Format("IJmapping/IJmapping_type_%s_flipx%i_flipy%i.txt", name[iname].Data(), iflipx, iflipy), TString::Format("IJmapping_type_%s_flipx%i_flipy%i.txt", name[iname].Data(), iflipx, iflipy), 1800, 400);

--- a/mapping/createmapping.C
+++ b/mapping/createmapping.C
@@ -19,91 +19,126 @@
 #include "TLatex.h"
 #include "../include/utils.h"
 
-//#include "../../style/Style.C"
-//#include "../../style/Labels.C"
+// #include "../../style/Style.C"
+// #include "../../style/Labels.C"
 
-using namespace std;
-
-void createmapping(TString run="PedestalMIP_3GeVMIPscan", TString gain="low"){
-  TString name[2]={"fev10","fev11_cob_rotate"};
-
-  for(int iname=0; iname<2; iname++) {
-
-    for(int iflipx=0; iflipx<2; iflipx++) {
-      for(int iflipy=0; iflipy<2; iflipy++) {
-
-	float flipx=1;
-	if(iflipx==1) flipx=-1;
-    	float flipy=1;
-	if(iflipy==1) flipy=-1;
-	
-  // TString mapstring="../../mapping/"+name[iname]+"_chip_channel_x_y_mapping.txt";
-  TString mapstring=name[iname]+"_chip_channel_x_y_mapping.txt";
-  ReadMap(mapstring,0);
-  TH2F* map =new TH2F("map","map; chip; chn",16,-0.5,15.5,64,-0.5,63.5);
-  TH2F* map_chip =new TH2F("map_chip","map; chip; chn",16,-0.5,15.5,1,-0.5,63.5);
-  TH2F* mapxy =new TH2F("mapxy","map-xy; x; y",32,-90,90,32,-90,90);
-  TH2F* mapIJ =new TH2F("mapIJ","map-IJ; I; J",32,-0.5,31.5,32,-0.5,31.5);
-  TH2F* mapxy_chip =new TH2F("mapxy_chip","map-xy; x; y",32,-90,90,32,-90,90);
-  TH2F* mapIJ_chip =new TH2F("mapIJ_chip","map-IJ; I; J",32,-0.5,31.5,32,-0.5,31.5);
-
-  for(int i=0;i<16;i++){
-    map_chip->Fill(i,0.,i+1);
-    for(int j=0; j<64; j++) {
-      mapxy_chip->Fill(-flipx*map_pointX[0][i][j],-flipy*map_pointY[0][i][j],i+1);
-      mapxy->Fill(-flipx*map_pointX[0][i][j],-flipy*map_pointY[0][i][j],j);
-      map->Fill(i,j);
-    }
-  }
-
-  ofstream fout_ped(TString::Format("IJmapping/IJmapping_type_%s_flipx%i_flipy%i.txt",name[iname].Data(),iflipx,iflipy).Data(),ios::out);
-  fout_ped<<"### IJmapping " <<endl;
-  fout_ped<<"## TYPE: "<<name[iname]<< " FLIPX: "<<iflipx<< " FLIPY: "<<iflipy <<endl;
-  fout_ped<<"#chip channel I J"<<endl;
-
-  double mappingarray_i[32][64];
-  double mappingarray_j[32][64];
-
-  for(int i=0; i<32; i++) {
-    for(int j=0; j<32; j++) {
-      mapIJ->Fill(i,j,mapxy->GetBinContent(i+1,j+1));
-      //if(mapIJ_chip->GetBinContent(i+1,j+1)==0)
-      mapIJ_chip->Fill(i,j,mapxy_chip->GetBinContent(i+1,j+1));
-      mappingarray_i[int(mapxy_chip->GetBinContent(i+1,j+1)-1)][int(mapxy->GetBinContent(i+1,j+1))]=i;
-      mappingarray_j[int(mapxy_chip->GetBinContent(i+1,j+1)-1)][int(mapxy->GetBinContent(i+1,j+1))]=j;
-
-    }
-  }
-  
-  for(int i=0; i<16; i++) {
-    for(int j=0; j<64; j++) {
-      fout_ped<<i<<" "<<j<<" "<<mappingarray_i[i][j]<<" "<<mappingarray_j[i][j]<<endl;
-    }
-  }
-  
-
-
-  gStyle->SetOptStat(0);
-  TCanvas* canvas2= new TCanvas(TString::Format("IJmapping/IJmapping_type_%s_flipx%i_flipy%i.txt",name[iname].Data(),iflipx,iflipy),TString::Format("IJmapping_type_%s_flipx%i_flipy%i.txt",name[iname].Data(),iflipx,iflipy),1800,400);   
-  canvas2->Divide(3,1);
-  canvas2->cd(1);
-  map_chip->Draw("colz");
-  // map->Draw("textsame");
-
-  canvas2->cd(2);
-  mapxy_chip->Draw("colz");
-  //  mapxy->SetMarkerColor(0);
-  mapxy->Draw("textsame");
-  canvas2->cd(2);
-
-  canvas2->cd(3);
-  mapIJ_chip->Draw("colz");
-  mapIJ->Draw("textsame");
-  canvas2->cd(2);
-  canvas2->Print(TString::Format("IJmapping/IJmapping_type_%s_flipx%i_flipy%i.pdf",name[iname].Data(),iflipx,iflipy));
-      }
-    }
-  }
+template <class P1>
+void StylePad(P1 *pad, Float_t t, Float_t b, Float_t r, Float_t l)
+{
+  pad->SetGrid(1,1);
+  if(t) pad->SetTopMargin(t);
+  if(b) pad->SetBottomMargin(b);
+  if(r) pad->SetRightMargin(r);
+  if(l) pad->SetLeftMargin(l);
+  pad->Draw();
+  pad->cd();
 
 }
 
+using namespace std;
+
+void createmapping(TString run = "PedestalMIP_3GeVMIPscan", TString gain = "low")
+{
+  TString name[2] = {"fev10", "fev11_cob_rotate"};
+
+  for (int iname = 0; iname < 2; iname++)
+  {
+
+    for (int iflipx = 0; iflipx < 2; iflipx++)
+    {
+      for (int iflipy = 0; iflipy < 2; iflipy++)
+      {
+
+        float flipx = 1;
+        if (iflipx == 1)
+          flipx = -1;
+        float flipy = 1;
+        if (iflipy == 1)
+          flipy = -1;
+
+        TString str_name = "IJmapping_type_" + name[iname] + "_flipx" + iflipx + "_flipy" + iflipy;
+
+        // TString mapstring="../../mapping/"+name[iname]+"_chip_channel_x_y_mapping.txt";
+        TString mapstring = name[iname] + "_chip_channel_x_y_mapping.txt";
+        ReadMap(mapstring, 0);
+        TH2F *map = new TH2F("map_" + str_name, "map; chip; chn", 16, -0.5, 15.5, 64, -0.5, 63.5);
+        TH2F *map_chip = new TH2F("map_chip_" + str_name, "map; chip; chn", 16, -0.5, 15.5, 1, -0.5, 63.5);
+        TH2F *mapxy = new TH2F("mapxy_" + str_name, "map-xy; x [mm]; y [mm]", 32, -90, 90, 32, -90, 90);
+        TH2F *mapIJ = new TH2F("mapIJ_" + str_name, "map-IJ; I; J", 32, -0.5, 31.5, 32, -0.5, 31.5);
+        TH2F *mapxy_chip = new TH2F("mapxy_chip_" + str_name, "map-xy; x; y", 32, -90, 90, 32, -90, 90);
+        TH2F *mapxy_chip_display = new TH2F("mapxy_chip_display_" + str_name, "map-xy; x; y", 4, -90, 90, 4, -90, 90);
+        TH2F *mapIJ_chip = new TH2F("mapIJ_chip_" + str_name, "map-IJ; I; J", 32, -0.5, 31.5, 32, -0.5, 31.5);
+
+        for (int i = 0; i < 16; i++)
+        {
+          map_chip->Fill(i, 0., i + 1);
+          mapxy_chip_display->Fill(-flipx * map_pointX[0][i][0], -flipy * map_pointY[0][i][0], i + 1);
+          for (int j = 0; j < 64; j++)
+          {
+            mapxy_chip->Fill(-flipx * map_pointX[0][i][j], -flipy * map_pointY[0][i][j], i + 1);
+            mapxy->Fill(-flipx * map_pointX[0][i][j], -flipy * map_pointY[0][i][j], j);
+            map->Fill(i, j);
+          }
+        }
+
+        ofstream fout_ped(TString::Format("IJmapping/IJmapping_type_%s_flipx%i_flipy%i.txt", name[iname].Data(), iflipx, iflipy).Data(), ios::out);
+        fout_ped << "### IJmapping " << endl;
+        fout_ped << "## TYPE: " << name[iname] << " FLIPX: " << iflipx << " FLIPY: " << iflipy << endl;
+        fout_ped << "#chip channel I J" << endl;
+
+        double mappingarray_i[32][64];
+        double mappingarray_j[32][64];
+
+        for (int i = 0; i < 32; i++)
+        {
+          for (int j = 0; j < 32; j++)
+          {
+            mapIJ->Fill(i, j, mapxy->GetBinContent(i + 1, j + 1));
+            // if(mapIJ_chip->GetBinContent(i+1,j+1)==0)
+            mapIJ_chip->Fill(i, j, mapxy_chip->GetBinContent(i + 1, j + 1));
+            mappingarray_i[int(mapxy_chip->GetBinContent(i + 1, j + 1) - 1)][int(mapxy->GetBinContent(i + 1, j + 1))] = i;
+            mappingarray_j[int(mapxy_chip->GetBinContent(i + 1, j + 1) - 1)][int(mapxy->GetBinContent(i + 1, j + 1))] = j;
+          }
+        }
+
+        for (int i = 0; i < 16; i++)
+        {
+          for (int j = 0; j < 64; j++)
+          {
+            fout_ped << i << " " << j << " " << mappingarray_i[i][j] << " " << mappingarray_j[i][j] << endl;
+          }
+        }
+
+        gStyle->SetOptStat(0);
+        TCanvas * canvas = new TCanvas(str_name,str_name, 900,900);
+        TPad *pad1 = new TPad("pad1", "pad1", 0, 0, 1, 1);
+        StylePad(pad1,0,0.15,0,0.15);
+        pad1->SetGrid(0,0);
+        mapxy_chip->SetTitle("");
+        mapxy_chip->Draw("col");
+        mapxy_chip_display->Draw("textsame");
+        // mapxy->Draw("textsame");
+
+        /*
+        TCanvas *canvas2 = new TCanvas(TString::Format("IJmapping/IJmapping_type_%s_flipx%i_flipy%i.txt", name[iname].Data(), iflipx, iflipy), TString::Format("IJmapping_type_%s_flipx%i_flipy%i.txt", name[iname].Data(), iflipx, iflipy), 1800, 400);
+        canvas2->Divide(3, 1);
+        canvas2->cd(1);
+        map_chip->Draw("colz");
+        // map->Draw("textsame");
+
+        canvas2->cd(2);
+        mapxy_chip->Draw("colz");
+        //  mapxy->SetMarkerColor(0);
+        mapxy->Draw("textsame");
+        canvas2->cd(2);
+
+        canvas2->cd(3);
+        mapIJ_chip->Draw("colz");
+        mapIJ->Draw("textsame");
+        canvas2->cd(2);
+        canvas2->Print(TString::Format("IJmapping/IJmapping_type_%s_flipx%i_flipy%i.pdf", name[iname].Data(), iflipx, iflipy));
+        */
+      }
+    }
+  }
+}

--- a/pedestals/GetPedestals.cpp
+++ b/pedestals/GetPedestals.cpp
@@ -1,0 +1,51 @@
+
+#include <iostream>
+#include <TFile.h>
+#include <TH1.h>
+#include <TCanvas.h>
+#include "../macros/Styles.hh"
+
+template <typename T>
+TCanvas* PlotPedestals(T hist, TString option)
+{
+  TString canvas_name = "c_" + TString(hist->GetName());
+  TString pad_name = "pad_" + TString(hist->GetName());
+  TCanvas* canvas = new TCanvas(canvas_name,canvas_name, 800, 800);
+  TPad *pad = new TPad(pad_name,pad_name,0,0,1,1);
+  pad->SetGrid(0,0);
+  StylePad(pad, 0.1, 0.15, 0.17, 0.15);
+  hist->GetZaxis()->SetTitle(hist->GetTitle());
+  hist->GetZaxis()->SetTitleOffset(1.5);
+  hist->GetXaxis()->SetTitleOffset(1.2);
+  hist->SetTitle(";Layer #times 20 + Chip;SCA #times 100 + Channel");
+  hist->Draw(option);
+  return canvas;
+}
+
+void GetPedestals(const char* filename) {
+  // Open the ROOT file
+  TFile* file = TFile::Open(filename);
+  if (!file) {
+    std::cerr << "Error: failed to open file " << filename << std::endl;
+    return;
+  }
+
+  // Extract the histograms
+  TH2F* ped_all = (TH2F*) file->Get("ped_all");
+  TH2F* width_all = dynamic_cast<TH2F*>(file->Get("width_all"));
+  if (!ped_all || !width_all) {
+    std::cerr << "Error: failed to extract histograms from file " << filename << std::endl;
+    file->Close();
+    return;
+  }
+
+  TCanvas *c_ped_all   = PlotPedestals(ped_all, "colz");
+  TCanvas *c_width_all = PlotPedestals(width_all, "colz");
+
+  // c_ped_all->Draw();
+  // c_width_all->Draw();
+
+  c_ped_all->SaveAs("plots/ped_all.pdf");
+  c_width_all->SaveAs("plots/ped_width_all.pdf");
+
+}

--- a/pedestals/PlotsPedestal.C
+++ b/pedestals/PlotsPedestal.C
@@ -7,12 +7,12 @@ void Plots(TString name_ = "run_050575_injection_merged_ILCEnergyElectrons", TSt
   int nchips = 16;
   int nsca = 3;
 
-  ReadPedestalsProtoCovariance("Pedestal_method2_" + name_ + "_" + st_gain + ".txt");
+  ReadPedestalsProtoCovariance("Pedestal_method1_" + name_ + "_" + st_gain + ".txt");
 
-  TFile *_file1 = new TFile(TString::Format("plots/PedSummaryPlots_method2_%s_%s.root", name_.Data(), st_gain.Data()), "RECREATE");
+  TFile *_file1 = new TFile(TString::Format("plots/PedSummaryPlots_method1_%s_%s.root", name_.Data(), st_gain.Data()), "RECREATE");
   _file1->cd();
 
-  TFile *file0 = TFile::Open(TString::Format("PedSummary_method2_%s_%s.root", name_.Data(), st_gain.Data()));
+  TFile *file0 = TFile::Open(TString::Format("PedSummary_method1_%s_%s.root", name_.Data(), st_gain.Data()));
   TH2F *h2ped = (TH2F *)file0->Get("ped");
   TH2F *h2ped_i = (TH2F *)file0->Get("ped_i");
   TH2F *h2ped_c1 = (TH2F *)file0->Get("ped_c1");
@@ -273,7 +273,7 @@ void PlotsPedestal()
 
   for (int j = 0; j < 2; j++)
   {
-    Plots("3GeVMIPscan_run_050060", gain[j]);
+    Plots("cosmic_long_062022_merged", gain[j]);
   }
 
   // for(int i=0; i<2; i++) {

--- a/pedestals/PlotsPedestal.C
+++ b/pedestals/PlotsPedestal.C
@@ -1,226 +1,284 @@
 #include "../include/utils.h"
 
-void Plots(TString name_="run_050575_injection_merged_ILCEnergyElectrons",TString st_gain="highgain"){
+void Plots(TString name_ = "run_050575_injection_merged_ILCEnergyElectrons", TString st_gain = "highgain")
+{
 
-  int nlayers=15;
-  int nchips=16;
-  int nsca=3;
-  
-  ReadPedestalsProtoCovariance("Pedestal_method2_"+name_+"_"+st_gain+".txt");
-  
-  TFile *_file1 = new TFile(TString::Format("plots/PedSummaryPlots_method2_%s_%s.root",name_.Data(),st_gain.Data()),"RECREATE");
+  int nlayers = 15;
+  int nchips = 16;
+  int nsca = 3;
+
+  ReadPedestalsProtoCovariance("Pedestal_method2_" + name_ + "_" + st_gain + ".txt");
+
+  TFile *_file1 = new TFile(TString::Format("plots/PedSummaryPlots_method2_%s_%s.root", name_.Data(), st_gain.Data()), "RECREATE");
   _file1->cd();
-  
-  TFile *file0 = TFile::Open(TString::Format("PedSummary_method2_%s_%s.root",name_.Data(),st_gain.Data()));
-  TH2F * h2ped=(TH2F*)file0->Get("ped");
-  TH2F * h2ped_i=(TH2F*)file0->Get("ped_i");
-  TH2F * h2ped_c1=(TH2F*)file0->Get("ped_c1");
-  TH2F * h2ped_c2=(TH2F*)file0->Get("ped_c2");
+
+  TFile *file0 = TFile::Open(TString::Format("PedSummary_method2_%s_%s.root", name_.Data(), st_gain.Data()));
+  TH2F *h2ped = (TH2F *)file0->Get("ped");
+  TH2F *h2ped_i = (TH2F *)file0->Get("ped_i");
+  TH2F *h2ped_c1 = (TH2F *)file0->Get("ped_c1");
+  TH2F *h2ped_c2 = (TH2F *)file0->Get("ped_c2");
 
   _file1->cd();
   h2ped->Write();
   h2ped_i->Write();
   h2ped_c1->Write();
   h2ped_c2->Write();
-  //h2ped->Save(TString::Format("pedestal_map_%s.png",st_gain.Data()));
-  //  h2ped_i->Save(TString::Format("incoherent_map_%s.png",st_gain.Data()));
+  // h2ped->Save(TString::Format("pedestal_map_%s.png",st_gain.Data()));
+  //   h2ped_i->Save(TString::Format("incoherent_map_%s.png",st_gain.Data()));
 
   delete file0;
 
-  for(int layer=0; layer<nlayers; layer++) {
-    cout<<layer<<endl;
+  for (int layer = 0; layer < nlayers; layer++)
+  {
+    cout << layer << endl;
     // TString map="../../../mapping/fev10_chip_channel_x_y_mapping.txt";
     // if(layer==2 || layer==3)  map="../../../mapping/fev11_cob_chip_channel_x_y_mapping.txt";
     // ReadMap(map,layer);
     TGraphErrors *g_rms[16];
     TGraphErrors *g_inoise[16];
     TGraphErrors *g_totalnoise[16];
-    double minimum=1.01;
-    if(st_gain=="lowgain") minimum=0.1;
-	
-    for(int chip=0; chip<nchips; chip++) {
+    double minimum = 1.01;
+    if (st_gain == "lowgain")
+      minimum = 0.1;
 
-      double x[15]={0}, ex[15]={0};
-      double yrms[15]={0}, eyrms[15]={0};
-      double yinoise[15]={0}, eyinoise[15]={0};
-      double ytotalnoise[15]={0}, eytotalnoise[15]={0};
-    
-      for(int isca=0; isca<nsca; isca++) {
-	x[isca]=isca;
+    for (int chip = 0; chip < nchips; chip++)
+    {
 
-	double yrms_=0, eyrms_=0, nrms_=0;
-	double yinoise_=0, eyinoise_=0, ninoise_=0;
-	double ytotalnoise_=0, eytotalnoise_=0, ntotalnoise_=0;
+      double x[15] = {0}, ex[15] = {0};
+      double yrms[15] = {0}, eyrms[15] = {0};
+      double yinoise[15] = {0}, eyinoise[15] = {0};
+      double ytotalnoise[15] = {0}, eytotalnoise[15] = {0};
 
-	//average
-	for(int j=0; j<64; j++) {
-	  if(ped_error_slboard.at(layer).at(chip).at(j).at(isca)>minimum) {
-	    yrms_+=ped_error_slboard.at(layer).at(chip).at(j).at(isca);
-	    nrms_++;
-	  }
-	  if(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca)>minimum) {
-	    yinoise_+=ped_w_i_slboard.at(layer).at(chip).at(j).at(isca);
-	    ninoise_++;
-	  }
-	  if(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca)>minimum) {
-	    ytotalnoise_+=sqrt(
-			       pow(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca),2)+
-			       pow(ped_w_c1_slboard.at(layer).at(chip).at(j).at(isca),2)+
-			       pow(ped_w_c2_slboard.at(layer).at(chip).at(j).at(isca),2));
-	    ntotalnoise_++;
-	  }
-	}//channel
+      for (int isca = 0; isca < nsca; isca++)
+      {
+        x[isca] = isca;
 
-	if(nrms_>0) yrms_/=nrms_;
-	else yrms_=0;
-	if(ninoise_>0) yinoise_/=ninoise_;
-	else yinoise_=0;
-	if(ntotalnoise_>0) ytotalnoise_/=ntotalnoise_;
-	else ytotalnoise_=0;
+        double yrms_ = 0, eyrms_ = 0, nrms_ = 0;
+        double yinoise_ = 0, eyinoise_ = 0, ninoise_ = 0;
+        double ytotalnoise_ = 0, eytotalnoise_ = 0, ntotalnoise_ = 0;
 
-	//std dev
-	for(int j=0; j<64; j++) {
-	  if(ped_error_slboard.at(layer).at(chip).at(j).at(isca)>minimum) {
-	    eyrms_+=pow(ped_error_slboard.at(layer).at(chip).at(j).at(isca)-yrms_,2);
-	  }
-	  if(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca)>minimum) {
-	    eyinoise_+=pow(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca)-yinoise_,2);
-	  }
-	  if(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca)>minimum) {
-	    eytotalnoise_+=pow(sqrt(
-				    pow(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca),2)+
-				    pow(ped_w_c1_slboard.at(layer).at(chip).at(j).at(isca),2)+
-				    pow(ped_w_c2_slboard.at(layer).at(chip).at(j).at(isca),2))
-			       -
-			       ytotalnoise_,2);
-	  }
-	}//channel
+        // average
+        for (int j = 0; j < 64; j++)
+        {
+          if (ped_error_slboard.at(layer).at(chip).at(j).at(isca) > minimum)
+          {
+            yrms_ += ped_error_slboard.at(layer).at(chip).at(j).at(isca);
+            nrms_++;
+          }
+          if (ped_w_i_slboard.at(layer).at(chip).at(j).at(isca) > minimum)
+          {
+            yinoise_ += ped_w_i_slboard.at(layer).at(chip).at(j).at(isca);
+            ninoise_++;
+          }
+          if (ped_w_i_slboard.at(layer).at(chip).at(j).at(isca) > minimum)
+          {
+            ytotalnoise_ += sqrt(
+                pow(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca), 2) +
+                pow(ped_w_c1_slboard.at(layer).at(chip).at(j).at(isca), 2) +
+                pow(ped_w_c2_slboard.at(layer).at(chip).at(j).at(isca), 2));
+            ntotalnoise_++;
+          }
+        } // channel
 
-	if(nrms_>0) eyrms_=sqrt(eyrms_/nrms_);
-	else eyrms_=0;
-	if(ninoise_>0) eyinoise_=sqrt(eyinoise_/ninoise_);
-	else eyinoise_=0;
-	if(ntotalnoise_>0) eytotalnoise_=sqrt(eytotalnoise_/ntotalnoise_);
-	else eytotalnoise_=0;
+        if (nrms_ > 0)
+          yrms_ /= nrms_;
+        else
+          yrms_ = 0;
+        if (ninoise_ > 0)
+          yinoise_ /= ninoise_;
+        else
+          yinoise_ = 0;
+        if (ntotalnoise_ > 0)
+          ytotalnoise_ /= ntotalnoise_;
+        else
+          ytotalnoise_ = 0;
 
-	yrms[isca]=yrms_; eyrms[isca]=eyrms_;
-  	yinoise[isca]=yinoise_; eyinoise[isca]=eyinoise_;
-	ytotalnoise[isca]=ytotalnoise_; eytotalnoise[isca]=eytotalnoise_;
+        // std dev
+        for (int j = 0; j < 64; j++)
+        {
+          if (ped_error_slboard.at(layer).at(chip).at(j).at(isca) > minimum)
+          {
+            eyrms_ += pow(ped_error_slboard.at(layer).at(chip).at(j).at(isca) - yrms_, 2);
+          }
+          if (ped_w_i_slboard.at(layer).at(chip).at(j).at(isca) > minimum)
+          {
+            eyinoise_ += pow(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca) - yinoise_, 2);
+          }
+          if (ped_w_i_slboard.at(layer).at(chip).at(j).at(isca) > minimum)
+          {
+            eytotalnoise_ += pow(sqrt(
+                                     pow(ped_w_i_slboard.at(layer).at(chip).at(j).at(isca), 2) +
+                                     pow(ped_w_c1_slboard.at(layer).at(chip).at(j).at(isca), 2) +
+                                     pow(ped_w_c2_slboard.at(layer).at(chip).at(j).at(isca), 2)) -
+                                     ytotalnoise_,
+                                 2);
+          }
+        } // channel
 
+        if (nrms_ > 0)
+          eyrms_ = sqrt(eyrms_ / nrms_);
+        else
+          eyrms_ = 0;
+        if (ninoise_ > 0)
+          eyinoise_ = sqrt(eyinoise_ / ninoise_);
+        else
+          eyinoise_ = 0;
+        if (ntotalnoise_ > 0)
+          eytotalnoise_ = sqrt(eytotalnoise_ / ntotalnoise_);
+        else
+          eytotalnoise_ = 0;
+
+        yrms[isca] = yrms_;
+        eyrms[isca] = eyrms_;
+        yinoise[isca] = yinoise_;
+        eyinoise[isca] = eyinoise_;
+        ytotalnoise[isca] = ytotalnoise_;
+        eytotalnoise[isca] = eytotalnoise_;
       }
-      g_rms[chip]=new TGraphErrors(nsca,x,yrms,ex,eyrms);
-      g_inoise[chip]=new TGraphErrors(nsca,x,yinoise,ex,eyinoise);
-      g_totalnoise[chip]=new TGraphErrors(nsca,x,ytotalnoise,ex,eytotalnoise);
+      g_rms[chip] = new TGraphErrors(nsca, x, yrms, ex, eyrms);
+      g_inoise[chip] = new TGraphErrors(nsca, x, yinoise, ex, eyinoise);
+      g_totalnoise[chip] = new TGraphErrors(nsca, x, ytotalnoise, ex, eytotalnoise);
 
-    }//ichip
-  
+    } // ichip
 
     _file1->cd();
- 					     
-    TCanvas* canvas0= new TCanvas(TString::Format("NoiseEstimations_%s_%s-layer%i",name_.Data(),st_gain.Data(),layer),TString::Format("NoiseEstimations_%s_%s-layer%i",name_.Data(),st_gain.Data(),layer),1200,1200);   
-    canvas0->Divide(2,2);
+
+    TCanvas *canvas0 = new TCanvas(TString::Format("NoiseEstimations_%s_%s-layer%i", name_.Data(), st_gain.Data(), layer), TString::Format("NoiseEstimations_%s_%s-layer%i", name_.Data(), st_gain.Data(), layer), 1200, 1200);
+    canvas0->Divide(2, 2);
     canvas0->cd(1);
-    TLegend * leg = new TLegend(0.2,0.2,0.8,0.8);
-    for(int chip=0; chip<16; chip++) {
-      if(chip!=9) {
-	g_rms[chip]->SetLineColor(chip+1);
-	g_rms[chip]->SetMarkerColor(chip+1);
-      } else {
-	g_rms[chip]->SetLineColor(1);
-	g_rms[chip]->SetMarkerColor(1);
+    TLegend *leg = new TLegend(0.2, 0.2, 0.8, 0.8);
+    for (int chip = 0; chip < 16; chip++)
+    {
+      if (chip != 9)
+      {
+        g_rms[chip]->SetLineColor(chip + 1);
+        g_rms[chip]->SetMarkerColor(chip + 1);
       }
-      g_rms[chip]->SetMarkerStyle(20+chip);
+      else
+      {
+        g_rms[chip]->SetLineColor(1);
+        g_rms[chip]->SetMarkerColor(1);
+      }
+      g_rms[chip]->SetMarkerStyle(20 + chip);
       g_rms[chip]->SetMarkerSize(1.);
 
-      
-      if ( chip % 2 == 0) g_rms[chip]->SetLineStyle(2);
-      else g_rms[chip]->SetLineStyle(1);
-      if ( chip % 2 == 0) g_rms[chip]->SetLineWidth(2);
-      else g_rms[chip]->SetLineWidth(4);
-      if(chip==0) {
-	g_rms[chip]->GetYaxis()->SetRangeUser(minimum,5);
-	g_rms[chip]->GetYaxis()->SetTitle("ADC");
-	g_rms[chip]->GetXaxis()->SetTitle("SCA");
-	g_rms[chip]->SetTitle("Pedestal RMS");
-	g_rms[chip]->Draw("alp");
+      if (chip % 2 == 0)
+        g_rms[chip]->SetLineStyle(2);
+      else
+        g_rms[chip]->SetLineStyle(1);
+      if (chip % 2 == 0)
+        g_rms[chip]->SetLineWidth(2);
+      else
+        g_rms[chip]->SetLineWidth(4);
+      if (chip == 0)
+      {
+        g_rms[chip]->GetYaxis()->SetRangeUser(minimum, 5);
+        g_rms[chip]->GetYaxis()->SetTitle("ADC");
+        g_rms[chip]->GetXaxis()->SetTitle("SCA");
+        g_rms[chip]->SetTitle("Pedestal RMS");
+        g_rms[chip]->Draw("alp");
       }
-      else g_rms[chip]->Draw("lp");
+      else
+        g_rms[chip]->Draw("lp");
       // g_rms[chip]->Write();
-      leg->AddEntry(g_rms[chip],TString::Format("ASIC:%i",chip),"lpe");
+      leg->AddEntry(g_rms[chip], TString::Format("ASIC:%i", chip), "lpe");
     }
 
     canvas0->cd(2);
-    for(int chip=0; chip<16; chip++) {
-      if(chip!=9) {
-	g_inoise[chip]->SetLineColor(chip+1);
-	g_inoise[chip]->SetMarkerColor(chip+1);
-      } else {
-	g_inoise[chip]->SetLineColor(1);
-	g_inoise[chip]->SetMarkerColor(1);
+    for (int chip = 0; chip < 16; chip++)
+    {
+      if (chip != 9)
+      {
+        g_inoise[chip]->SetLineColor(chip + 1);
+        g_inoise[chip]->SetMarkerColor(chip + 1);
       }
-      g_inoise[chip]->SetMarkerStyle(20+chip);
+      else
+      {
+        g_inoise[chip]->SetLineColor(1);
+        g_inoise[chip]->SetMarkerColor(1);
+      }
+      g_inoise[chip]->SetMarkerStyle(20 + chip);
       g_inoise[chip]->SetMarkerSize(1.);
 
-      
-      if ( chip % 2 == 0) g_inoise[chip]->SetLineStyle(2);
-      else g_inoise[chip]->SetLineStyle(1);
-      if ( chip % 2 == 0) g_inoise[chip]->SetLineWidth(2);
-      else g_inoise[chip]->SetLineWidth(4);
-      if(chip==0) {
-	g_inoise[chip]->GetYaxis()->SetRangeUser(minimum,5);
-	g_inoise[chip]->GetYaxis()->SetTitle("ADC");
-	g_inoise[chip]->GetXaxis()->SetTitle("SCA");
-	g_inoise[chip]->SetTitle("Pedestal Incoherent Noise");
-	g_inoise[chip]->Draw("alp");
+      if (chip % 2 == 0)
+        g_inoise[chip]->SetLineStyle(2);
+      else
+        g_inoise[chip]->SetLineStyle(1);
+      if (chip % 2 == 0)
+        g_inoise[chip]->SetLineWidth(2);
+      else
+        g_inoise[chip]->SetLineWidth(4);
+      if (chip == 0)
+      {
+        g_inoise[chip]->GetYaxis()->SetRangeUser(minimum, 5);
+        g_inoise[chip]->GetYaxis()->SetTitle("ADC");
+        g_inoise[chip]->GetXaxis()->SetTitle("SCA");
+        g_inoise[chip]->SetTitle("Pedestal Incoherent Noise");
+        g_inoise[chip]->Draw("alp");
       }
-      else g_inoise[chip]->Draw("lp");
+      else
+        g_inoise[chip]->Draw("lp");
       //  g_inoise[chip]->Write();
     }
 
     canvas0->cd(3);
-    for(int chip=0; chip<16; chip++) {
-      if(chip!=9) {
-	g_totalnoise[chip]->SetLineColor(chip+1);
-	g_totalnoise[chip]->SetMarkerColor(chip+1);
-      } else {
-	g_totalnoise[chip]->SetLineColor(1);
-	g_totalnoise[chip]->SetMarkerColor(1);
+    for (int chip = 0; chip < 16; chip++)
+    {
+      if (chip != 9)
+      {
+        g_totalnoise[chip]->SetLineColor(chip + 1);
+        g_totalnoise[chip]->SetMarkerColor(chip + 1);
       }
-      g_totalnoise[chip]->SetMarkerStyle(20+chip);
+      else
+      {
+        g_totalnoise[chip]->SetLineColor(1);
+        g_totalnoise[chip]->SetMarkerColor(1);
+      }
+      g_totalnoise[chip]->SetMarkerStyle(20 + chip);
       g_totalnoise[chip]->SetMarkerSize(1.);
 
-      
-      if ( chip % 2 == 0) g_totalnoise[chip]->SetLineStyle(2);
-      else g_totalnoise[chip]->SetLineStyle(1);
-      if ( chip % 2 == 0) g_totalnoise[chip]->SetLineWidth(2);
-      else g_totalnoise[chip]->SetLineWidth(4);
-      if(chip==0) {
-	g_totalnoise[chip]->GetYaxis()->SetRangeUser(minimum,5);
-	g_totalnoise[chip]->GetYaxis()->SetTitle("ADC");
-	g_totalnoise[chip]->GetXaxis()->SetTitle("SCA");
-	g_totalnoise[chip]->SetTitle("Pedestal incoherent+coherent noise");
-	g_totalnoise[chip]->Draw("alp");
+      if (chip % 2 == 0)
+        g_totalnoise[chip]->SetLineStyle(2);
+      else
+        g_totalnoise[chip]->SetLineStyle(1);
+      if (chip % 2 == 0)
+        g_totalnoise[chip]->SetLineWidth(2);
+      else
+        g_totalnoise[chip]->SetLineWidth(4);
+      if (chip == 0)
+      {
+        g_totalnoise[chip]->GetYaxis()->SetRangeUser(minimum, 5);
+        g_totalnoise[chip]->GetYaxis()->SetTitle("ADC");
+        g_totalnoise[chip]->GetXaxis()->SetTitle("SCA");
+        g_totalnoise[chip]->SetTitle("Pedestal incoherent+coherent noise");
+        g_totalnoise[chip]->Draw("alp");
       }
-      else g_totalnoise[chip]->Draw("lp");
+      else
+        g_totalnoise[chip]->Draw("lp");
       //      g_totalnoise[chip]->Write();
     }
-    
+
     canvas0->cd(4);
     leg->Draw();
     canvas0->Write();
-    canvas0->Print(TString::Format("plots/NoiseEstimations_layer%i_%s.png",layer,st_gain.Data()));
-    }
+    canvas0->Print(TString::Format("plots/NoiseEstimations_layer%i_%s.png", layer, st_gain.Data()));
+  }
 }
 
-void PlotsPedestal(){
+void PlotsPedestal()
+{
 
-  TString runs[2]={"run_050571_injection_merged_LowEnergyElectrons","run_050575_injection_merged_ILCEnergyElectrons"};
-  TString gain[2]={"highgain","lowgain"};
-  
-  for(int i=0; i<2; i++) {
-    for(int j=0; j<2; j++) {
-      Plots(runs[i],gain[j]);      
-    }
+  TString runs[2] = {"run_050571_injection_merged_LowEnergyElectrons", "run_050575_injection_merged_ILCEnergyElectrons"};
+  TString gain[2] = {"highgain", "lowgain"};
+
+  for (int j = 0; j < 2; j++)
+  {
+    Plots("3GeVMIPscan_run_050060", gain[j]);
   }
 
+  // for(int i=0; i<2; i++) {
+  //   for(int j=0; j<2; j++) {
+  //     Plots(runs[i],gain[j]);
+  //   }
+  // }
 }


### PR DESCRIPTION
This is duplicate PR from https://github.com/SiWECAL-TestBeam/SiWECAL-TB-analysis/pull/43

# Bug Fix
Some fix for bug was done that's affect energy calculation.

## Average MIP calculation

### Symptom
MIP values for the bad cells were assigned to be somewhere between 0 - 1.

### Issue
In the `ecal_config.py`, the script calculates the average MIP value for the chip by taking the mean in the array `channel_is_used_for_average`. Yet this is a boolean array.

### Solution
`channel_is_used_for_average` is replaced with `channel_is_used_for_average_with_mpv` which is an array with array with MIP values. Average now calculates the mean of all the good MIP values.

## Energy calculation
Minor bug fix for the energy calculation, in the function `_redo_fill_event` which is not really used.